### PR TITLE
Single Compilation Unit build.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -14,6 +14,7 @@ from collections import OrderedDict
 # Local
 import methods
 import gles_builders
+import scu_builders
 from platform_methods import run_in_subprocess
 
 # scan possible build platforms
@@ -86,6 +87,7 @@ env_base.__class__.disable_module = methods.disable_module
 env_base.__class__.add_module_version_string = methods.add_module_version_string
 
 env_base.__class__.add_source_files = methods.add_source_files
+env_base.__class__.add_source_files_scu = methods.add_source_files_scu
 env_base.__class__.use_windows_spawn_fix = methods.use_windows_spawn_fix
 env_base.__class__.split_lib = methods.split_lib
 
@@ -155,6 +157,7 @@ opts.Add(BoolVariable("disable_advanced_gui", "Disable advanced GUI nodes and be
 opts.Add(BoolVariable("no_editor_splash", "Don't use the custom splash screen for the editor", True))
 opts.Add("system_certs_path", "Use this path as SSL certificates default for editor (for package maintainers)", "")
 opts.Add(BoolVariable("use_precise_math_checks", "Math checks use very precise epsilon (debug option)", False))
+opts.Add(BoolVariable("use_scu", "Use single compilation unit build", False))
 opts.Add(
     EnumVariable(
         "rids",
@@ -335,6 +338,12 @@ else:
     # Disable assert() for production targets (only used in thirdparty code).
     env_base.Append(CPPDEFINES=["NDEBUG"])
 
+    # SCU builds currently use too much compiler memory
+    # in release builds, so disallow except in DEV builds.
+    if env_base["use_scu"]:
+        print("WARNING: SCU build flag ignored in non-DEV builds.")
+        env_base["use_scu"] = False
+
 # SCons speed optimization controlled by the `fast_unsafe` option, which provide
 # more than 10 s speed up for incremental rebuilds.
 # Unsafe as they reduce the certainty of rebuilding all changed files, so it's
@@ -441,6 +450,10 @@ if selected_platform in platform_list:
                 "this will give you a full debug template (use `target=release_debug` "
                 "for an optimized template with debug features)."
             )
+
+    # Run SCU file generation script if in a SCU build.
+    if env["use_scu"]:
+        scu_builders.generate_scu_files(env["verbose"])
 
     # Must happen after the flags' definition, as configure is when most flags
     # are actually handled to change compile options, etc.

--- a/core/SCsub
+++ b/core/SCsub
@@ -152,8 +152,7 @@ env.core_sources += thirdparty_obj
 
 
 # Godot source files
-
-env.add_source_files(env.core_sources, "*.cpp")
+env.add_source_files_scu(env.core_sources, "*.cpp")
 env.add_source_files(env.core_sources, "script_encryption_key.gen.cpp")
 env.add_source_files(env.core_sources, "version_hash.gen.cpp")
 

--- a/core/color_names.inc
+++ b/core/color_names.inc
@@ -1,4 +1,6 @@
 // Names from https://en.wikipedia.org/wiki/X11_color_names
+#pragma once
+
 #include "core/map.h"
 
 static Map<String, Color> _named_colors;

--- a/core/crypto/SCsub
+++ b/core/crypto/SCsub
@@ -45,7 +45,7 @@ if not has_module:
 
 core_obj = []
 
-env_crypto.add_source_files(core_obj, "*.cpp")
+env_crypto.add_source_files_scu(core_obj, "*.cpp")
 env.core_sources += core_obj
 
 # Needed to force rebuilding the core files when the thirdparty library is updated.

--- a/core/io/SCsub
+++ b/core/io/SCsub
@@ -2,4 +2,4 @@
 
 Import("env")
 
-env.add_source_files(env.core_sources, "*.cpp")
+env.add_source_files_scu(env.core_sources, "*.cpp")

--- a/core/make_binders.py
+++ b/core/make_binders.py
@@ -86,7 +86,8 @@ MethodBind* create_method_bind($ifret R$ $ifnoret void$ (T::*p_method)($arg, P@$
 #endif
 """
 
-template = """
+template = """#pragma once
+
 #ifndef TYPED_METHOD_BIND
 $iftempl template<$ $ifret class R$ $ifretargs ,$ $arg, class P@$ $iftempl >$
 class MethodBind$argc$$ifret R$$ifconst C$ : public MethodBind {

--- a/core/math/SCsub
+++ b/core/math/SCsub
@@ -4,4 +4,4 @@ Import("env")
 
 env_math = env.Clone()
 
-env_math.add_source_files(env.core_sources, "*.cpp")
+env_math.add_source_files_scu(env.core_sources, "*.cpp")

--- a/core/os/SCsub
+++ b/core/os/SCsub
@@ -2,4 +2,4 @@
 
 Import("env")
 
-env.add_source_files(env.core_sources, "*.cpp")
+env.add_source_files_scu(env.core_sources, "*.cpp")

--- a/drivers/gles2/SCsub
+++ b/drivers/gles2/SCsub
@@ -2,6 +2,6 @@
 
 Import("env")
 
-env.add_source_files(env.drivers_sources, "*.cpp")
+env.add_source_files_scu(env.drivers_sources, "*.cpp")
 
 SConscript("shaders/SCsub")

--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -53,7 +53,7 @@
 #endif
 #endif
 
-static const GLenum _cube_side_enum[6] = {
+const GLenum RasterizerSceneGLES2::_cube_side_enum[6] = {
 
 	GL_TEXTURE_CUBE_MAP_NEGATIVE_X,
 	GL_TEXTURE_CUBE_MAP_POSITIVE_X,
@@ -1332,7 +1332,7 @@ void RasterizerSceneGLES2::_fill_render_list(InstanceBase **p_cull_result, int p
 	}
 }
 
-static const GLenum gl_primitive[] = {
+const GLenum RasterizerSceneGLES2::gl_primitive[] = {
 	GL_POINTS,
 	GL_LINES,
 	GL_LINE_STRIP,

--- a/drivers/gles2/rasterizer_scene_gles2.h
+++ b/drivers/gles2/rasterizer_scene_gles2.h
@@ -89,6 +89,8 @@ public:
 
 private:
 	uint32_t _light_counter;
+	static const GLenum gl_primitive[];
+	static const GLenum _cube_side_enum[6];
 
 public:
 	RasterizerStorageGLES2 *storage;

--- a/drivers/gles2/shader_gles2.cpp
+++ b/drivers/gles2/shader_gles2.cpp
@@ -126,7 +126,7 @@ static void _display_error_with_code(const String &p_error, const Vector<const c
 	ERR_PRINT(p_error);
 }
 
-static String _mkid(const String &p_id) {
+String ShaderGLES2::_mkid(const String &p_id) {
 	String id = "m_" + p_id;
 	return id.replace("__", "_dus_"); //doubleunderscore is reserved in glsl
 }

--- a/drivers/gles2/shader_gles2.h
+++ b/drivers/gles2/shader_gles2.h
@@ -51,6 +51,8 @@
 class RasterizerStorageGLES2;
 
 class ShaderGLES2 {
+	static String _mkid(const String &p_id);
+
 protected:
 	struct Enum {
 		uint64_t mask;

--- a/drivers/gles3/SCsub
+++ b/drivers/gles3/SCsub
@@ -2,6 +2,6 @@
 
 Import("env")
 
-env.add_source_files(env.drivers_sources, "*.cpp")
+env.add_source_files_scu(env.drivers_sources, "*.cpp")
 
 SConscript("shaders/SCsub")

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -41,7 +41,7 @@
 #define glClearDepth glClearDepthf
 #endif
 
-static const GLenum _cube_side_enum[6] = {
+const GLenum RasterizerSceneGLES3::_cube_side_enum[6] = {
 
 	GL_TEXTURE_CUBE_MAP_NEGATIVE_X,
 	GL_TEXTURE_CUBE_MAP_POSITIVE_X,
@@ -52,7 +52,7 @@ static const GLenum _cube_side_enum[6] = {
 
 };
 
-static _FORCE_INLINE_ void store_transform(const Transform &p_mtx, float *p_array) {
+void RasterizerSceneGLES3::store_transform(const Transform &p_mtx, float *p_array) {
 	p_array[0] = p_mtx.basis.elements[0][0];
 	p_array[1] = p_mtx.basis.elements[1][0];
 	p_array[2] = p_mtx.basis.elements[2][0];
@@ -71,7 +71,7 @@ static _FORCE_INLINE_ void store_transform(const Transform &p_mtx, float *p_arra
 	p_array[15] = 1;
 }
 
-static _FORCE_INLINE_ void store_camera(const CameraMatrix &p_mtx, float *p_array) {
+void RasterizerSceneGLES3::store_camera(const CameraMatrix &p_mtx, float *p_array) {
 	for (int i = 0; i < 4; i++) {
 		for (int j = 0; j < 4; j++) {
 			p_array[i * 4 + j] = p_mtx.matrix[i][j];
@@ -1482,7 +1482,7 @@ void RasterizerSceneGLES3::_setup_geometry(RenderList::Element *e, const Transfo
 	}
 }
 
-static const GLenum gl_primitive[] = {
+const GLenum RasterizerSceneGLES3::gl_primitive[] = {
 	GL_POINTS,
 	GL_LINES,
 	GL_LINE_STRIP,

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -863,6 +863,13 @@ public:
 	virtual void set_scene_pass(uint64_t p_pass);
 	virtual void set_debug_draw_mode(VS::ViewportDebugDraw p_debug_draw);
 
+private:
+	_FORCE_INLINE_ void store_transform(const Transform &p_mtx, float *p_array);
+	_FORCE_INLINE_ void store_camera(const CameraMatrix &p_mtx, float *p_array);
+	static const GLenum gl_primitive[];
+	static const GLenum _cube_side_enum[6];
+
+public:
 	void iteration();
 	void initialize();
 	void finalize();

--- a/drivers/png/SCsub
+++ b/drivers/png/SCsub
@@ -64,7 +64,7 @@ if env["builtin_libpng"]:
 
 driver_obj = []
 
-env_png.add_source_files(driver_obj, "*.cpp")
+env_png.add_source_files_scu(driver_obj, "*.cpp")
 env.drivers_sources += driver_obj
 
 # Needed to force rebuilding the driver files when the thirdparty library is updated.

--- a/drivers/unix/SCsub
+++ b/drivers/unix/SCsub
@@ -2,6 +2,6 @@
 
 Import("env")
 
-env.add_source_files(env.drivers_sources, "*.cpp")
+env.add_source_files_scu(env.drivers_sources, "*.cpp")
 
 env["check_c_headers"] = [["mntent.h", "HAVE_MNTENT"]]

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -101,7 +101,7 @@ if env["tools"]:
     env.Depends("#editor/builtin_fonts.gen.h", flist)
     env.CommandNoCache("#editor/builtin_fonts.gen.h", flist, run_in_subprocess(editor_builders.make_fonts_header))
 
-    env.add_source_files(env.editor_sources, "*.cpp")
+    env.add_source_files_scu(env.editor_sources, "*.cpp")
     env.add_source_files(env.editor_sources, "register_exporters.gen.cpp")
 
     SConscript("collada/SCsub")

--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -37,7 +37,7 @@
 #include "editor_node.h"
 
 // The metadata key used to store and retrieve the version text to copy to the clipboard.
-static const String META_TEXT_TO_COPY = "text_to_copy";
+const String EditorAbout::META_TEXT_TO_COPY = "text_to_copy";
 
 void EditorAbout::_notification(int p_what) {
 	switch (p_what) {

--- a/editor/editor_about.h
+++ b/editor/editor_about.h
@@ -53,6 +53,7 @@ class EditorAbout : public AcceptDialog {
 	GDCLASS(EditorAbout, AcceptDialog);
 
 private:
+	static const String META_TEXT_TO_COPY;
 	void _license_tree_selected();
 	void _version_button_pressed();
 	ScrollContainer *_populate_list(const String &p_name, const List<String> &p_sections, const char *const *const p_src[], const int p_flag_single_column = 0);

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -43,20 +43,6 @@
 #include "scene/property_utils.h"
 #include "scene/resources/packed_scene.h"
 
-static bool _property_path_matches(const String &p_property_path, const String &p_filter, EditorPropertyNameProcessor::Style p_style) {
-	if (p_property_path.findn(p_filter) != -1) {
-		return true;
-	}
-
-	const Vector<String> sections = p_property_path.split("/");
-	for (int i = 0; i < sections.size(); i++) {
-		if (p_filter.is_subsequence_ofi(EditorPropertyNameProcessor::get_singleton()->process_name(sections[i], p_style))) {
-			return true;
-		}
-	}
-	return false;
-}
-
 Size2 EditorProperty::get_minimum_size() const {
 	Size2 ms;
 	Ref<Font> font = get_font("font", "Tree");
@@ -1236,6 +1222,20 @@ EditorInspectorSection::~EditorInspectorSection() {
 
 Ref<EditorInspectorPlugin> EditorInspector::inspector_plugins[MAX_PLUGINS];
 int EditorInspector::inspector_plugin_count = 0;
+
+bool EditorInspector::_property_path_matches(const String &p_property_path, const String &p_filter, EditorPropertyNameProcessor::Style p_style) {
+	if (p_property_path.findn(p_filter) != -1) {
+		return true;
+	}
+
+	const Vector<String> sections = p_property_path.split("/");
+	for (int i = 0; i < sections.size(); i++) {
+		if (p_filter.is_subsequence_ofi(EditorPropertyNameProcessor::get_singleton()->process_name(sections[i], p_style))) {
+			return true;
+		}
+	}
+	return false;
+}
 
 EditorProperty *EditorInspector::instantiate_property_editor(Object *p_object, Variant::Type p_type, const String &p_path, PropertyHint p_hint, const String &p_hint_text, int p_usage) {
 	for (int i = inspector_plugin_count - 1; i >= 0; i--) {

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -317,6 +317,7 @@ class EditorInspector : public ScrollContainer {
 	void _property_keyed_with_value(const String &p_path, const Variant &p_value, bool p_advance);
 	void _property_checked(const String &p_path, bool p_checked);
 	void _property_pinned(const String &p_path, bool p_pinned);
+	bool _property_path_matches(const String &p_property_path, const String &p_filter, EditorPropertyNameProcessor::Style p_style);
 
 	void _resource_selected(const String &p_path, RES p_resource);
 	void _property_selected(const String &p_path, int p_focusable);

--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -34,20 +34,6 @@
 #include "editor_scale.h"
 #include "editor_settings.h"
 
-static bool _property_path_matches(const String &p_property_path, const String &p_filter, EditorPropertyNameProcessor::Style p_style) {
-	if (p_property_path.findn(p_filter) != -1) {
-		return true;
-	}
-
-	const Vector<String> sections = p_property_path.split("/");
-	for (int i = 0; i < sections.size(); i++) {
-		if (p_filter.is_subsequence_ofi(EditorPropertyNameProcessor::get_singleton()->process_name(sections[i], p_style))) {
-			return true;
-		}
-	}
-	return false;
-}
-
 class SectionedInspectorFilter : public Object {
 	GDCLASS(SectionedInspectorFilter, Object);
 
@@ -144,6 +130,20 @@ public:
 		edited = nullptr;
 	}
 };
+
+bool SectionedInspector::_property_path_matches(const String &p_property_path, const String &p_filter, EditorPropertyNameProcessor::Style p_style) {
+	if (p_property_path.findn(p_filter) != -1) {
+		return true;
+	}
+
+	const Vector<String> sections = p_property_path.split("/");
+	for (int i = 0; i < sections.size(); i++) {
+		if (p_filter.is_subsequence_ofi(EditorPropertyNameProcessor::get_singleton()->process_name(sections[i], p_style))) {
+			return true;
+		}
+	}
+	return false;
+}
 
 void SectionedInspector::_bind_methods() {
 	ClassDB::bind_method("_section_selected", &SectionedInspector::_section_selected);

--- a/editor/editor_sectioned_inspector.h
+++ b/editor/editor_sectioned_inspector.h
@@ -55,6 +55,7 @@ class SectionedInspector : public HSplitContainer {
 	void _section_selected();
 
 	void _search_changed(const String &p_what);
+	bool _property_path_matches(const String &p_property_path, const String &p_filter, EditorPropertyNameProcessor::Style p_style);
 
 protected:
 	void _notification(int p_what);

--- a/editor/import/SCsub
+++ b/editor/import/SCsub
@@ -2,4 +2,4 @@
 
 Import("env")
 
-env.add_source_files(env.editor_sources, "*.cpp")
+env.add_source_files_scu(env.editor_sources, "*.cpp")

--- a/editor/plugins/SCsub
+++ b/editor/plugins/SCsub
@@ -2,4 +2,4 @@
 
 Import("env")
 
-env.add_source_files(env.editor_sources, "*.cpp")
+env.add_source_files_scu(env.editor_sources, "*.cpp")

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -494,7 +494,7 @@ void TextEditor::_bind_methods() {
 	ClassDB::bind_method("_prepare_edit_menu", &TextEditor::_prepare_edit_menu);
 }
 
-static ScriptEditorBase *create_editor(const RES &p_resource) {
+ScriptEditorBase *TextEditor::create_editor(const RES &p_resource) {
 	if (Object::cast_to<TextFile>(*p_resource)) {
 		return memnew(TextEditor);
 	}

--- a/editor/plugins/text_editor.h
+++ b/editor/plugins/text_editor.h
@@ -96,6 +96,7 @@ private:
 		BOOKMARK_GOTO_PREV,
 		BOOKMARK_REMOVE_ALL,
 	};
+	static ScriptEditorBase *create_editor(const RES &p_resource);
 
 protected:
 	static void _bind_methods();

--- a/main/SCsub
+++ b/main/SCsub
@@ -7,7 +7,7 @@ import main_builders
 
 env.main_sources = []
 
-env.add_source_files(env.main_sources, "*.cpp")
+env.add_source_files_scu(env.main_sources, "*.cpp")
 
 # Order matters here. Higher index controller database files write on top of lower index database files.
 controller_databases = ["gamecontrollerdb.txt", "godotcontrollerdb.txt"]

--- a/main/tests/SCsub
+++ b/main/tests/SCsub
@@ -3,7 +3,7 @@
 Import("env")
 
 env.tests_sources = []
-env.add_source_files(env.tests_sources, "*.cpp")
+env.add_source_files_scu(env.tests_sources, "*.cpp")
 
 lib = env.add_library("tests", env.tests_sources)
 env.Prepend(LIBS=[lib])

--- a/main/tests/test_string.cpp
+++ b/main/tests/test_string.cpp
@@ -1330,3 +1330,5 @@ MainLoop *test() {
 	return nullptr;
 }
 } // namespace TestString
+
+#undef CHECK

--- a/main/tests/test_theme.cpp
+++ b/main/tests/test_theme.cpp
@@ -301,3 +301,5 @@ MainLoop *test() {
 	return nullptr;
 }
 } // namespace TestTheme
+
+#undef CHECK

--- a/modules/bullet/SCsub
+++ b/modules/bullet/SCsub
@@ -213,7 +213,7 @@ if env["builtin_bullet"]:
 
 module_obj = []
 
-env_bullet.add_source_files(module_obj, "*.cpp")
+env_bullet.add_source_files_scu(module_obj, "*.cpp")
 env.modules_sources += module_obj
 
 # Needed to force rebuilding the module files when the thirdparty library is updated.

--- a/modules/csg/SCsub
+++ b/modules/csg/SCsub
@@ -6,4 +6,4 @@ Import("env_modules")
 env_csg = env_modules.Clone()
 
 # Godot source files
-env_csg.add_source_files(env.modules_sources, "*.cpp")
+env_csg.add_source_files_scu(env.modules_sources, "*.cpp")

--- a/modules/fbx/SCsub
+++ b/modules/fbx/SCsub
@@ -11,8 +11,10 @@ env_fbx.Prepend(CPPPATH=["#modules/fbx/"])
 if env["builtin_zlib"]:
     env_fbx.Prepend(CPPPATH=["#thirdparty/zlib/"])
 
-# Godot source files
-env_fbx.add_source_files(env.modules_sources, "tools/*.cpp")
-env_fbx.add_source_files(env.modules_sources, "data/*.cpp")
-env_fbx.add_source_files(env.modules_sources, "fbx_parser/*.cpp")
-env_fbx.add_source_files(env.modules_sources, "*.cpp")
+# Either add all the folders in one go if a SCU build...
+if env_fbx.add_source_files_scu(env.modules_sources, "*.cpp") == False:
+    # or if not a scu build, the above line only adds the main folder,
+    # and the subfolders are added separately:
+    env_fbx.add_source_files(env.modules_sources, "tools/*.cpp")
+    env_fbx.add_source_files(env.modules_sources, "data/*.cpp")
+    env_fbx.add_source_files(env.modules_sources, "fbx_parser/*.cpp")

--- a/modules/gdnative/SCsub
+++ b/modules/gdnative/SCsub
@@ -4,13 +4,15 @@ Import("env")
 Import("env_modules")
 
 env_gdnative = env_modules.Clone()
-env_gdnative.add_source_files(env.modules_sources, "gdnative.cpp")
-env_gdnative.add_source_files(env.modules_sources, "register_types.cpp")
-env_gdnative.add_source_files(env.modules_sources, "android/*.cpp")
-env_gdnative.add_source_files(env.modules_sources, "gdnative/*.cpp")
-env_gdnative.add_source_files(env.modules_sources, "nativescript/*.cpp")
-env_gdnative.add_source_files(env.modules_sources, "gdnative_library_singleton_editor.cpp")
-env_gdnative.add_source_files(env.modules_sources, "gdnative_library_editor_plugin.cpp")
+
+
+# Either add all the folders in one go if a SCU build...
+if env_gdnative.add_source_files_scu(env.modules_sources, "*.cpp") == False:
+    # or if not a scu build, the above line only adds the main folder,
+    # and the subfolders are added separately:
+    env_gdnative.add_source_files(env.modules_sources, "android/*.cpp")
+    env_gdnative.add_source_files(env.modules_sources, "gdnative/*.cpp")
+    env_gdnative.add_source_files(env.modules_sources, "nativescript/*.cpp")
 
 env_gdnative.Prepend(CPPPATH=["#modules/gdnative/include/"])
 

--- a/modules/gdnative/arvr/SCsub
+++ b/modules/gdnative/arvr/SCsub
@@ -3,4 +3,4 @@
 Import("env")
 Import("env_gdnative")
 
-env_gdnative.add_source_files(env.modules_sources, "*.cpp")
+env_gdnative.add_source_files_scu(env.modules_sources, "*.cpp")

--- a/modules/gdnative/net/SCsub
+++ b/modules/gdnative/net/SCsub
@@ -9,4 +9,4 @@ has_webrtc = env_net["module_webrtc_enabled"]
 if has_webrtc:
     env_net.Append(CPPDEFINES=["WEBRTC_GDNATIVE_ENABLED"])
 
-env_net.add_source_files(env.modules_sources, "*.cpp")
+env_net.add_source_files_scu(env.modules_sources, "*.cpp")

--- a/modules/gdnative/pluginscript/SCsub
+++ b/modules/gdnative/pluginscript/SCsub
@@ -3,4 +3,4 @@
 Import("env")
 Import("env_gdnative")
 
-env_gdnative.add_source_files(env.modules_sources, "*.cpp")
+env_gdnative.add_source_files_scu(env.modules_sources, "*.cpp")

--- a/modules/gdscript/SCsub
+++ b/modules/gdscript/SCsub
@@ -5,14 +5,14 @@ Import("env_modules")
 
 env_gdscript = env_modules.Clone()
 
-env_gdscript.add_source_files(env.modules_sources, "*.cpp")
+env_gdscript.add_source_files_scu(env.modules_sources, "*.cpp")
 
 if env["tools"]:
     env_gdscript.add_source_files(env.modules_sources, "./editor/*.cpp")
 
     # Those two modules are required for the language server protocol
     if env["module_jsonrpc_enabled"] and env["module_websocket_enabled"]:
-        env_gdscript.add_source_files(env.modules_sources, "./language_server/*.cpp")
+        env_gdscript.add_source_files_scu(env.modules_sources, "./language_server/*.cpp")
     else:
         # Using a define in the disabled case, to avoid having an extra define
         # in regular builds where all modules are enabled.

--- a/modules/gltf/SCsub
+++ b/modules/gltf/SCsub
@@ -6,6 +6,6 @@ Import("env_modules")
 env_gltf = env_modules.Clone()
 
 # Godot source files
-env_gltf.add_source_files(env.modules_sources, "*.cpp")
-env_gltf.add_source_files(env.modules_sources, "structures/*.cpp")
+env_gltf.add_source_files_scu(env.modules_sources, "*.cpp")
+env_gltf.add_source_files_scu(env.modules_sources, "structures/*.cpp")
 SConscript("extensions/SCsub")

--- a/modules/gridmap/SCsub
+++ b/modules/gridmap/SCsub
@@ -6,4 +6,4 @@ Import("env_modules")
 env_gridmap = env_modules.Clone()
 
 # Godot source files
-env_gridmap.add_source_files(env.modules_sources, "*.cpp")
+env_gridmap.add_source_files_scu(env.modules_sources, "*.cpp")

--- a/modules/navigation/SCsub
+++ b/modules/navigation/SCsub
@@ -55,7 +55,7 @@ if env["builtin_rvo2"]:
 
 module_obj = []
 
-env_navigation.add_source_files(module_obj, "*.cpp")
+env_navigation.add_source_files_scu(module_obj, "*.cpp")
 
 env.modules_sources += module_obj
 

--- a/modules/visual_script/SCsub
+++ b/modules/visual_script/SCsub
@@ -5,4 +5,4 @@ Import("env_modules")
 
 env_vs = env_modules.Clone()
 
-env_vs.add_source_files(env.modules_sources, "*.cpp")
+env_vs.add_source_files_scu(env.modules_sources, "*.cpp")

--- a/modules/visual_script/visual_script_editor.cpp
+++ b/modules/visual_script/visual_script_editor.cpp
@@ -2227,27 +2227,6 @@ bool VisualScriptEditor::can_drop_data_fw(const Point2 &p_point, const Variant &
 	return false;
 }
 
-static Node *_find_script_node(Node *p_edited_scene, Node *p_current_node, const Ref<Script> &script) {
-	if (p_edited_scene != p_current_node && p_current_node->get_owner() != p_edited_scene) {
-		return nullptr;
-	}
-
-	Ref<Script> scr = p_current_node->get_script();
-
-	if (scr.is_valid() && scr == script) {
-		return p_current_node;
-	}
-
-	for (int i = 0; i < p_current_node->get_child_count(); i++) {
-		Node *n = _find_script_node(p_edited_scene, p_current_node->get_child(i), script);
-		if (n) {
-			return n;
-		}
-	}
-
-	return nullptr;
-}
-
 void VisualScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {
 	if (p_from != graph) {
 		return;
@@ -2441,7 +2420,7 @@ void VisualScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_da
 	}
 
 	if (String(d["type"]) == "nodes") {
-		Node *sn = _find_script_node(get_tree()->get_edited_scene_root(), get_tree()->get_edited_scene_root(), script);
+		Node *sn = NSVisualScript::_find_script_node(get_tree()->get_edited_scene_root(), get_tree()->get_edited_scene_root(), script);
 
 		if (!sn) {
 			EditorNode::get_singleton()->show_warning(vformat(TTR("Can't drop nodes because script '%s' is not used in this scene."), get_name()));
@@ -2495,7 +2474,7 @@ void VisualScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_da
 	}
 
 	if (String(d["type"]) == "obj_property") {
-		Node *sn = _find_script_node(get_tree()->get_edited_scene_root(), get_tree()->get_edited_scene_root(), script);
+		Node *sn = NSVisualScript::_find_script_node(get_tree()->get_edited_scene_root(), get_tree()->get_edited_scene_root(), script);
 
 		if (!sn && !Input::get_singleton()->is_key_pressed(KEY_SHIFT)) {
 			EditorNode::get_singleton()->show_warning(vformat(TTR("Can't drop properties because script '%s' is not used in this scene.\nDrop holding 'Shift' to just copy the signature."), get_name()));
@@ -4145,7 +4124,7 @@ void VisualScriptEditor::_default_value_edited(Node *p_button, int p_id, int p_i
 	if (pinfo.type == Variant::NODE_PATH) {
 		Node *edited_scene = get_tree()->get_edited_scene_root();
 		if (edited_scene) { // Fixing an old crash bug ( Visual Script Crashes on editing NodePath with an empty scene open)
-			Node *script_node = _find_script_node(edited_scene, edited_scene, script);
+			Node *script_node = NSVisualScript::_find_script_node(edited_scene, edited_scene, script);
 
 			if (script_node) {
 				//pick a node relative to the script, IF the script exists

--- a/modules/visual_script/visual_script_func_nodes.cpp
+++ b/modules/visual_script/visual_script_func_nodes.cpp
@@ -53,30 +53,7 @@ int VisualScriptFunctionCall::get_output_sequence_port_count() const {
 bool VisualScriptFunctionCall::has_input_sequence_port() const {
 	return !((method_cache.flags & METHOD_FLAG_CONST && call_mode != CALL_MODE_INSTANCE) || (call_mode == CALL_MODE_BASIC_TYPE && Variant::is_method_const(basic_type, function)));
 }
-#ifdef TOOLS_ENABLED
 
-static Node *_find_script_node(Node *p_edited_scene, Node *p_current_node, const Ref<Script> &script) {
-	if (p_edited_scene != p_current_node && p_current_node->get_owner() != p_edited_scene) {
-		return nullptr;
-	}
-
-	Ref<Script> scr = p_current_node->get_script();
-
-	if (scr.is_valid() && scr == script) {
-		return p_current_node;
-	}
-
-	for (int i = 0; i < p_current_node->get_child_count(); i++) {
-		Node *n = _find_script_node(p_edited_scene, p_current_node->get_child(i), script);
-		if (n) {
-			return n;
-		}
-	}
-
-	return nullptr;
-}
-
-#endif
 Node *VisualScriptFunctionCall::_get_base_node() const {
 #ifdef TOOLS_ENABLED
 	Ref<Script> script = get_visual_script();
@@ -97,7 +74,7 @@ Node *VisualScriptFunctionCall::_get_base_node() const {
 		return nullptr;
 	}
 
-	Node *script_node = _find_script_node(edited_scene, edited_scene, script);
+	Node *script_node = NSVisualScript::_find_script_node(edited_scene, edited_scene, script);
 
 	if (!script_node) {
 		return nullptr;
@@ -933,7 +910,7 @@ Node *VisualScriptPropertySet::_get_base_node() const {
 		return nullptr;
 	}
 
-	Node *script_node = _find_script_node(edited_scene, edited_scene, script);
+	Node *script_node = NSVisualScript::_find_script_node(edited_scene, edited_scene, script);
 
 	if (!script_node) {
 		return nullptr;
@@ -1682,7 +1659,7 @@ Node *VisualScriptPropertyGet::_get_base_node() const {
 		return nullptr;
 	}
 
-	Node *script_node = _find_script_node(edited_scene, edited_scene, script);
+	Node *script_node = NSVisualScript::_find_script_node(edited_scene, edited_scene, script);
 
 	if (!script_node) {
 		return nullptr;

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -2342,7 +2342,8 @@ VisualScriptNodeInstance *VisualScriptSceneNode::instance(VisualScriptInstance *
 
 #ifdef TOOLS_ENABLED
 
-static Node *_find_script_node(Node *p_edited_scene, Node *p_current_node, const Ref<Script> &script) {
+namespace NSVisualScript {
+Node *_find_script_node(Node *p_edited_scene, Node *p_current_node, const Ref<Script> &script) {
 	if (p_edited_scene != p_current_node && p_current_node->get_owner() != p_edited_scene) {
 		return nullptr;
 	}
@@ -2354,7 +2355,7 @@ static Node *_find_script_node(Node *p_edited_scene, Node *p_current_node, const
 	}
 
 	for (int i = 0; i < p_current_node->get_child_count(); i++) {
-		Node *n = _find_script_node(p_edited_scene, p_current_node->get_child(i), script);
+		Node *n = NSVisualScript::_find_script_node(p_edited_scene, p_current_node->get_child(i), script);
 		if (n) {
 			return n;
 		}
@@ -2362,6 +2363,7 @@ static Node *_find_script_node(Node *p_edited_scene, Node *p_current_node, const
 
 	return nullptr;
 }
+} //namespace NSVisualScript
 
 #endif
 
@@ -2389,7 +2391,7 @@ VisualScriptSceneNode::TypeGuess VisualScriptSceneNode::guess_output_type(TypeGu
 		return tg;
 	}
 
-	Node *script_node = _find_script_node(edited_scene, edited_scene, script);
+	Node *script_node = NSVisualScript::_find_script_node(edited_scene, edited_scene, script);
 
 	if (!script_node) {
 		return tg;
@@ -2426,7 +2428,7 @@ void VisualScriptSceneNode::_validate_property(PropertyInfo &property) const {
 			return;
 		}
 
-		Node *script_node = _find_script_node(edited_scene, edited_scene, script);
+		Node *script_node = NSVisualScript::_find_script_node(edited_scene, edited_scene, script);
 
 		if (!script_node) {
 			return;

--- a/modules/visual_script/visual_script_nodes.h
+++ b/modules/visual_script/visual_script_nodes.h
@@ -1060,4 +1060,10 @@ public:
 void register_visual_script_nodes();
 void unregister_visual_script_nodes();
 
+#ifdef TOOLS_ENABLED
+namespace NSVisualScript {
+Node *_find_script_node(Node *p_edited_scene, Node *p_current_node, const Ref<Script> &script);
+}
+#endif
+
 #endif // VISUAL_SCRIPT_NODES_H

--- a/modules/visual_script/visual_script_yield_nodes.cpp
+++ b/modules/visual_script/visual_script_yield_nodes.cpp
@@ -217,30 +217,7 @@ int VisualScriptYieldSignal::get_output_sequence_port_count() const {
 bool VisualScriptYieldSignal::has_input_sequence_port() const {
 	return true;
 }
-#ifdef TOOLS_ENABLED
 
-static Node *_find_script_node(Node *p_edited_scene, Node *p_current_node, const Ref<Script> &script) {
-	if (p_edited_scene != p_current_node && p_current_node->get_owner() != p_edited_scene) {
-		return nullptr;
-	}
-
-	Ref<Script> scr = p_current_node->get_script();
-
-	if (scr.is_valid() && scr == script) {
-		return p_current_node;
-	}
-
-	for (int i = 0; i < p_current_node->get_child_count(); i++) {
-		Node *n = _find_script_node(p_edited_scene, p_current_node->get_child(i), script);
-		if (n) {
-			return n;
-		}
-	}
-
-	return nullptr;
-}
-
-#endif
 Node *VisualScriptYieldSignal::_get_base_node() const {
 #ifdef TOOLS_ENABLED
 	Ref<Script> script = get_visual_script();
@@ -261,7 +238,7 @@ Node *VisualScriptYieldSignal::_get_base_node() const {
 		return nullptr;
 	}
 
-	Node *script_node = _find_script_node(edited_scene, edited_scene, script);
+	Node *script_node = NSVisualScript::_find_script_node(edited_scene, edited_scene, script);
 
 	if (!script_node) {
 		return nullptr;

--- a/modules/webrtc/SCsub
+++ b/modules/webrtc/SCsub
@@ -14,4 +14,4 @@ if env["platform"] == "javascript":
     # Our JavaScript/C++ interface.
     env.AddJSLibraries(["library_godot_webrtc.js"])
 
-env_webrtc.add_source_files(env.modules_sources, "*.cpp")
+env_webrtc.add_source_files_scu(env.modules_sources, "*.cpp")

--- a/modules/websocket/SCsub
+++ b/modules/websocket/SCsub
@@ -40,7 +40,7 @@ elif env["builtin_wslay"]:
 
 module_obj = []
 
-env_ws.add_source_files(module_obj, "*.cpp")
+env_ws.add_source_files_scu(module_obj, "*.cpp")
 env.modules_sources += module_obj
 
 # Needed to force rebuilding the module files when the thirdparty library is updated.

--- a/scene/2d/SCsub
+++ b/scene/2d/SCsub
@@ -2,4 +2,4 @@
 
 Import("env")
 
-env.add_source_files(env.scene_sources, "*.cpp")
+env.add_source_files_scu(env.scene_sources, "*.cpp")

--- a/scene/3d/SCsub
+++ b/scene/3d/SCsub
@@ -9,4 +9,4 @@ if env["disable_3d"]:
     env.add_source_files(env.scene_sources, "visual_instance.cpp")
     env.add_source_files(env.scene_sources, "world_environment.cpp")
 else:
-    env.add_source_files(env.scene_sources, "*.cpp")
+    env.add_source_files_scu(env.scene_sources, "*.cpp")

--- a/scene/SCsub
+++ b/scene/SCsub
@@ -5,7 +5,7 @@ Import("env")
 env.scene_sources = []
 
 # Godot source files
-env.add_source_files(env.scene_sources, "*.cpp")
+env.add_source_files_scu(env.scene_sources, "*.cpp")
 
 # Chain load SCsubs
 SConscript("main/SCsub")

--- a/scene/animation/SCsub
+++ b/scene/animation/SCsub
@@ -6,5 +6,5 @@ Import("env")
 
 scene_obj = []
 
-env.add_source_files(scene_obj, "*.cpp")
+env.add_source_files_scu(scene_obj, "*.cpp")
 env.scene_sources += scene_obj

--- a/scene/gui/SCsub
+++ b/scene/gui/SCsub
@@ -2,4 +2,4 @@
 
 Import("env")
 
-env.add_source_files(env.scene_sources, "*.cpp")
+env.add_source_files_scu(env.scene_sources, "*.cpp")

--- a/scene/gui/box_container.cpp
+++ b/scene/gui/box_container.cpp
@@ -32,12 +32,6 @@
 #include "label.h"
 #include "margin_container.h"
 
-struct _MinSizeCache {
-	int min_size;
-	bool will_stretch;
-	int final_size;
-};
-
 void BoxContainer::_resort() {
 	/** First pass, determine minimum size AND amount of stretchable elements */
 

--- a/scene/gui/box_container.h
+++ b/scene/gui/box_container.h
@@ -36,6 +36,12 @@
 class BoxContainer : public Container {
 	GDCLASS(BoxContainer, Container);
 
+	struct _MinSizeCache {
+		int min_size;
+		bool will_stretch;
+		int final_size;
+	};
+
 public:
 	enum AlignMode {
 		ALIGN_BEGIN,

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -44,7 +44,7 @@
 #include "editor/editor_settings.h"
 #endif
 
-static bool _is_text_char(CharType c) {
+bool LineEdit::_is_text_char(CharType c) {
 	return !is_symbol(c);
 }
 

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -150,6 +150,7 @@ private:
 	void _text_changed();
 	void _emit_text_change();
 	bool expand_to_text_length;
+	bool _is_text_char(CharType c);
 
 	void update_cached_width();
 	void update_placeholder_width();

--- a/scene/main/SCsub
+++ b/scene/main/SCsub
@@ -2,4 +2,4 @@
 
 Import("env")
 
-env.add_source_files(env.scene_sources, "*.cpp")
+env.add_source_files_scu(env.scene_sources, "*.cpp")

--- a/scene/resources/SCsub
+++ b/scene/resources/SCsub
@@ -17,7 +17,7 @@ env.scene_sources += thirdparty_obj
 
 scene_obj = []
 
-env.add_source_files(scene_obj, "*.cpp")
+env.add_source_files_scu(scene_obj, "*.cpp")
 env.scene_sources += scene_obj
 
 # Needed to force rebuilding the scene files when the thirdparty code is updated.

--- a/scu_builders.py
+++ b/scu_builders.py
@@ -1,0 +1,299 @@
+"""Functions used to generate scu build source files during build time
+
+"""
+import glob, os
+import math
+from pathlib import Path
+from os.path import normpath, basename
+
+base_folder = os.path.abspath("./") + "/"
+_verbose = False
+
+
+def clear_out_existing_files(output_folder, extension):
+    output_folder = os.path.abspath(output_folder)
+    # print("clear_out_existing_files from folder: " + output_folder)
+
+    if not os.path.isdir(output_folder):
+        # folder does not exist or has not been created yet,
+        # no files to clearout. (this is not an error)
+        return
+
+    os.chdir(output_folder)
+
+    for file in glob.glob("*." + extension):
+        # print("removed pre-existing file: " + file)
+        os.remove(file)
+
+
+def find_files_in_folder(folder, sub_folder, include_list, extension, sought_exceptions, found_exceptions):
+    abs_folder = base_folder + folder + "/" + sub_folder
+
+    if not os.path.isdir(abs_folder):
+        print("ERROR " + abs_folder + " not found.")
+        return include_list, found_exceptions
+
+    os.chdir(abs_folder)
+
+    sub_folder_slashed = ""
+    if sub_folder != "":
+        sub_folder_slashed = sub_folder + "/"
+
+    for file in glob.glob("*." + extension):
+
+        simple_name = Path(file).stem
+
+        if file.endswith(".gen.cpp"):
+            continue
+
+        li = '#include "../' + sub_folder_slashed + file + '"'
+
+        if not simple_name in sought_exceptions:
+            include_list += [li]
+        else:
+            found_exceptions += [li]
+
+    return include_list, found_exceptions
+
+
+def write_output_file(file_count, include_list, start_line, end_line, output_folder, output_filename_prefix, extension):
+
+    output_folder = os.path.abspath(output_folder)
+
+    if not os.path.isdir(output_folder):
+        # create
+        os.mkdir(output_folder)
+        if not os.path.isdir(output_folder):
+            print("ERROR " + output_folder + " could not be created.")
+            return
+        print("CREATING folder " + output_folder)
+
+    file_text = ""
+
+    for l in range(start_line, end_line):
+        if l < len(include_list):
+            line = include_list[l]
+            li = line + "\n"
+            file_text += li
+
+    # print(file_text)
+
+    num_string = ""
+    if file_count > 0:
+        num_string = "_" + str(file_count)
+
+    short_filename = output_filename_prefix + num_string + ".gen." + extension
+    output_filename = output_folder + "/" + short_filename
+    if _verbose:
+        print("generating: " + short_filename)
+
+    # return
+    output_file = open(output_filename, "w")
+    if not output_file.closed:
+        output_file.write(file_text)
+        output_file.close()
+
+
+def write_exception_output_file(file_count, exception_string, output_folder, output_filename_prefix, extension):
+    output_folder = os.path.abspath(output_folder)
+    if not os.path.isdir(output_folder):
+        print("ERROR " + output_folder + " does not exist.")
+        return
+
+    file_text = exception_string + "\n"
+
+    num_string = ""
+    if file_count > 0:
+        num_string = "_" + str(file_count)
+
+    short_filename = output_filename_prefix + "_exception" + num_string + ".gen." + extension
+    output_filename = output_folder + "/" + short_filename
+
+    if _verbose:
+        print("generating: " + short_filename)
+
+    # print("text: " + file_text)
+    # return
+    output_file = open(output_filename, "w")
+    if not output_file.closed:
+        output_file.write(file_text)
+        output_file.close()
+
+
+def find_section_name(sub_folder):
+    # Construct a useful name for the section from the path for debug logging
+    section_path = os.path.abspath(base_folder + sub_folder) + "/"
+
+    folders = []
+    folder = ""
+
+    for i in range(8):
+        folder = os.path.dirname(section_path)
+        folder = os.path.basename(folder)
+        if folder == "godot":
+            break
+        folders += [folder]
+        section_path += "../"
+        section_path = os.path.abspath(section_path) + "/"
+
+    section_name = ""
+    for n in range(len(folders)):
+        section_name += folders[len(folders) - n - 1]
+        if n != (len(folders) - 1):
+            section_name += "_"
+
+    return section_name
+
+
+# "folders" is a list of folders to add all the files from to add to the SCU
+# "section (like a module)". The name of the scu file will be derived from the first folder
+# (thus e.g. scene/3d becomes scu_scene_3d.gen.cpp)
+
+# "num_output_files" allows the scu to be built in several translation units instead of just 1.
+# This will usually be slower to compile but will use less memory per compiler instance, which
+# is most relevant in release builds.
+
+# "sought_exceptions" are a list of files (without extension) that contain
+# e.g. naming conflicts, and are therefore not suitable for the scu build.
+# These will automatically be placed in their own separate scu file,
+# which is slow like a normal build, but prevents the naming conflicts.
+# Ideally in these situations, the source code should be changed to prevent naming conflicts.
+
+# "extension" will usually be cpp, but can also be set to c (for e.g. third party libraries that use c)
+def process_folder(folders, sought_exceptions=[], num_output_files=1, extension="cpp"):
+    if len(folders) == 0:
+        return
+
+    # Construct the filename prefix from the FIRST folder name
+    # e.g. "scene_3d"
+    out_filename = find_section_name(folders[0])
+
+    found_includes = []
+    found_exceptions = []
+
+    main_folder = folders[0]
+    abs_main_folder = base_folder + main_folder
+
+    # main folder (first)
+    found_includes, found_exceptions = find_files_in_folder(
+        main_folder, "", found_includes, extension, sought_exceptions, found_exceptions
+    )
+
+    # sub folders
+    for d in range(1, len(folders)):
+        found_includes, found_exceptions = find_files_in_folder(
+            main_folder, folders[d], found_includes, extension, sought_exceptions, found_exceptions
+        )
+
+    found_includes = sorted(found_includes)
+
+    # calculate how many lines to write in each file
+    total_lines = len(found_includes)
+    lines_per_file = math.floor(total_lines / num_output_files)
+    lines_per_file = max(lines_per_file, 1)
+
+    start_line = 0
+    file_number = 0
+
+    # These do not vary throughout the loop
+    output_folder = abs_main_folder + "/scu/"
+    output_filename_prefix = "scu_" + out_filename
+
+    # Clear out any existing files (usually we will be overwriting,
+    # but we want to remove any that are pre-existing that will not be
+    # overwritten, so as to not compile anything stale)
+    clear_out_existing_files(output_folder, extension)
+
+    for file_count in range(0, num_output_files):
+        end_line = start_line + lines_per_file
+
+        # special case to cover rounding error in final file
+        if file_count == (num_output_files - 1):
+            end_line = len(found_includes)
+
+        write_output_file(
+            file_count, found_includes, start_line, end_line, output_folder, output_filename_prefix, extension
+        )
+
+        start_line = end_line
+
+    # Write the exceptions each in their own scu gen file,
+    # so they can effectively compile in "old style / normal build".
+    for exception_count in range(len(found_exceptions)):
+        write_exception_output_file(
+            exception_count, found_exceptions[exception_count], output_folder, output_filename_prefix, extension
+        )
+
+
+def generate_scu_files(verbose):
+
+    print("=============================")
+    print("Single Compilation Unit Build")
+    print("=============================")
+    print("Generating SCU build files")
+    global _verbose
+    _verbose = verbose
+
+    # check we are running from the correct folder
+    curr_folder = os.path.abspath("./")
+    parent_path = basename(normpath(curr_folder))
+
+    if parent_path != "godot":
+        print("ERROR - scu_builders.py must be run from the godot folder.")
+        return
+
+    process_folder(["core"])
+    process_folder(["core/math"])
+    process_folder(["core/os"])
+    process_folder(["core/io"])
+    process_folder(["core/crypto"])
+
+    process_folder(["drivers/gles2"])
+    process_folder(["drivers/gles3"])
+    process_folder(["drivers/unix"])
+    process_folder(["drivers/png"])
+
+    process_folder(["editor"])
+    process_folder(["editor/import"])
+    process_folder(["editor/plugins"])
+
+    process_folder(["main"])
+    process_folder(["main/tests"])
+
+    process_folder(["modules/bullet"])
+    process_folder(["modules/gltf"])
+    process_folder(["modules/gltf/structures"])
+    process_folder(["modules/navigation"])
+    process_folder(["modules/visual_script"])
+    process_folder(["modules/webrtc"])
+    process_folder(["modules/websocket"])
+    process_folder(["modules/gridmap"])
+
+    process_folder(["modules/csg"])
+    process_folder(["modules/gdscript"])
+    process_folder(["modules/gdscript/language_server"])
+    process_folder(["modules/fbx", "tools/", "data", "fbx_parser"])
+    process_folder(["modules/gdnative", "android", "gdnative", "nativescript"])
+    process_folder(["modules/gdnative/arvr"])
+    process_folder(["modules/gdnative/pluginscript"])
+    process_folder(["modules/gdnative/net"])
+
+    process_folder(["scene"])
+    process_folder(["scene/2d"])
+    process_folder(["scene/3d"])
+    process_folder(["scene/animation"])
+    process_folder(["scene/gui"])
+    process_folder(["scene/main"])
+    process_folder(["scene/resources"])
+
+    process_folder(["servers"])
+    process_folder(["servers/visual"])
+    process_folder(["servers/visual/portals"])
+    process_folder(["servers/physics_2d"])
+    process_folder(["servers/physics"])
+    process_folder(["servers/physics/joints"])
+    process_folder(["servers/audio"])
+    process_folder(["servers/audio/effects"])
+
+    # Finally change back the path to the calling folder
+    os.chdir(curr_folder)

--- a/servers/SCsub
+++ b/servers/SCsub
@@ -3,7 +3,7 @@
 Import("env")
 
 env.servers_sources = []
-env.add_source_files(env.servers_sources, "*.cpp")
+env.add_source_files_scu(env.servers_sources, "*.cpp")
 
 SConscript("arvr/SCsub")
 SConscript("camera/SCsub")

--- a/servers/audio/SCsub
+++ b/servers/audio/SCsub
@@ -2,6 +2,6 @@
 
 Import("env")
 
-env.add_source_files(env.servers_sources, "*.cpp")
+env.add_source_files_scu(env.servers_sources, "*.cpp")
 
 SConscript("effects/SCsub")

--- a/servers/audio/effects/SCsub
+++ b/servers/audio/effects/SCsub
@@ -2,4 +2,4 @@
 
 Import("env")
 
-env.add_source_files(env.servers_sources, "*.cpp")
+env.add_source_files_scu(env.servers_sources, "*.cpp")

--- a/servers/physics/SCsub
+++ b/servers/physics/SCsub
@@ -2,6 +2,6 @@
 
 Import("env")
 
-env.add_source_files(env.servers_sources, "*.cpp")
+env.add_source_files_scu(env.servers_sources, "*.cpp")
 
 SConscript("joints/SCsub")

--- a/servers/physics/joints/SCsub
+++ b/servers/physics/joints/SCsub
@@ -2,4 +2,4 @@
 
 Import("env")
 
-env.add_source_files(env.servers_sources, "*.cpp")
+env.add_source_files_scu(env.servers_sources, "*.cpp")

--- a/servers/physics/joints/hinge_joint_sw.cpp
+++ b/servers/physics/joints/hinge_joint_sw.cpp
@@ -49,7 +49,7 @@ subject to the following restrictions:
 
 #include "hinge_joint_sw.h"
 
-static void plane_space(const Vector3 &n, Vector3 &p, Vector3 &q) {
+void HingeJointSW::plane_space(const Vector3 &n, Vector3 &p, Vector3 &q) {
 	if (Math::abs(n.z) > Math_SQRT12) {
 		// choose p in y-z plane
 		real_t a = n[1] * n[1] + n[2] * n[2];
@@ -382,7 +382,7 @@ void	HingeJointSW::updateRHS(real_t	timeStep)
 }
 */
 
-static _FORCE_INLINE_ real_t atan2fast(real_t y, real_t x) {
+real_t HingeJointSW::atan2fast(real_t y, real_t x) {
 	real_t coeff_1 = Math_PI / 4.0f;
 	real_t coeff_2 = 3.0f * coeff_1;
 	real_t abs_y = Math::abs(y);

--- a/servers/physics/joints/hinge_joint_sw.h
+++ b/servers/physics/joints/hinge_joint_sw.h
@@ -95,6 +95,9 @@ class HingeJointSW : public JointSW {
 
 	real_t m_appliedImpulse;
 
+	void plane_space(const Vector3 &n, Vector3 &p, Vector3 &q);
+	_FORCE_INLINE_ real_t atan2fast(real_t y, real_t x);
+
 public:
 	virtual PhysicsServer::JointType get_type() const { return PhysicsServer::JOINT_HINGE; }
 

--- a/servers/physics/joints/slider_joint_sw.cpp
+++ b/servers/physics/joints/slider_joint_sw.cpp
@@ -57,7 +57,7 @@ April 04, 2008
 
 //-----------------------------------------------------------------------------
 
-static _FORCE_INLINE_ real_t atan2fast(real_t y, real_t x) {
+real_t SliderJointSW::atan2fast(real_t y, real_t x) {
 	real_t coeff_1 = Math_PI / 4.0f;
 	real_t coeff_2 = 3.0f * coeff_1;
 	real_t abs_y = Math::abs(y);

--- a/servers/physics/joints/slider_joint_sw.h
+++ b/servers/physics/joints/slider_joint_sw.h
@@ -150,6 +150,9 @@ protected:
 	//------------------------
 	void initParams();
 
+private:
+	_FORCE_INLINE_ real_t atan2fast(real_t y, real_t x);
+
 public:
 	// constructors
 	SliderJointSW(BodySW *rbA, BodySW *rbB, const Transform &frameInA, const Transform &frameInB);

--- a/servers/physics_2d/SCsub
+++ b/servers/physics_2d/SCsub
@@ -2,4 +2,4 @@
 
 Import("env")
 
-env.add_source_files(env.servers_sources, "*.cpp")
+env.add_source_files_scu(env.servers_sources, "*.cpp")

--- a/servers/visual/SCsub
+++ b/servers/visual/SCsub
@@ -2,6 +2,6 @@
 
 Import("env")
 
-env.add_source_files(env.servers_sources, "*.cpp")
+env.add_source_files_scu(env.servers_sources, "*.cpp")
 
 SConscript("portals/SCsub")

--- a/servers/visual/portals/SCsub
+++ b/servers/visual/portals/SCsub
@@ -2,4 +2,4 @@
 
 Import("env")
 
-env.add_source_files(env.servers_sources, "*.cpp")
+env.add_source_files_scu(env.servers_sources, "*.cpp")


### PR DESCRIPTION
_AKA Unity / Jumbo builds._

Adds support for simple SCU build (DEV_ENABLED only). This speeds up compilation by compiling multiple cpp files within a single translation unit.

This is an **optional** extra build that occurs when you set `use_scu=yes` in Scons. It currently only works in conjunction with DEV builds. All other regular builds work as normal.

## FAQ
* SCU builds are **TOTALLY OPTIONAL**.
If you wish you can totally ignore the existence of this build, and forget they exist.
* SCU builds are primarily for contributors, to speed up iteration time during development by reducing compilation time. This is particularly useful for people who would prefer to be productive.

## Introduction
<details>
<summary>Especially relevant for those that have not used this type of build before.</summary>
SCU builds (aka "unity" or "jumbo" builds) are a widely used technique for speeding up compilation. 
https://en.wikipedia.org/wiki/Single_compilation_unit

In a vanilla build one cpp file is fed to the compiler each time (one translation unit). In suboptimal setups, each cpp can end up including a large chain of header files, and might easily result in tens of thousands of lines of code to compile, for a cpp that may only be small.

If we consider that the majority of time is spent compiling headers that have a "once" directive (or include guards) then we can speed up compilation dramatically by compiling several cpps in the same translation unit. We can do this by supplying a master cpp file (called a "scu" file here) which is simply a list of the multiple cpp files we wish to include in the translation unit.

Thus for instance:
`scu_drivers_gles2.gen.cpp` contains:
```
#include "../rasterizer_canvas_base_gles2.cpp"
#include "../rasterizer_canvas_gles2.cpp"
#include "../rasterizer_gles2.cpp"
#include "../rasterizer_scene_gles2.cpp"
#include "../rasterizer_storage_gles2.cpp"
#include "../shader_compiler_gles2.cpp"
#include "../shader_gles2.cpp"
```
Any headers are compiled once and shared between all the cpps in the scu file.

This typically greatly speeds up compilation.

In return there are several downsides:
### SCU builds rely on not polluting the global namespace
If variables / functions within the cpps in the translation unit are duplicates, you will get build conflicts. These must be resolved (or better avoided in the first place), or else excluded from the accelerated build (and use old style compilation).

In general, polluting the global namespace is now regarded as a faux pas in modern programming, so this helps, but you will still find old school code that abuses global namespace, and relies on single cpp as a primitive form of scoping. Many of our third party libraries are not suitable without modification.

### Touching any file within a scu translation unit will cause the whole translation unit to recompile
Vanilla builds touching a single cpp are often cheaper. But generally touching a header (which is the rate limiting step) will be _much_ cheaper in SCU builds.
</details>

## Description
<details>

The PR contains 3 elements:

1) New functionality in `scu_builders.py` which is called from `SConstruct` (if the `use_scu=yes` Scons option is set).

This code builds all the necessary `scu_*.gen.cpp` files in corresponding `scu` subfolders that are necessary for the build to work. `scu_builders.py` should rarely need modifying, and only is concerned with keeping the scu build working, the regular builds are unaffected.

2) `SCsub` files _only_ for those modules we want to accelerate (mostly Godot core) are slightly modified to use the `add_source_files_scu()` function instead of `add_source_files()`. These should be for folders that have a corresponding entry in `scu_builders.py`.

`add_source_files_scu()` is usually used to add the main folder for the `SCsub`, using something like `*.cpp` for the file list. It returns either `True` (if the SCU build is active) or `False` if a regular build is taking place, in which case `add_source_files_scu()` passes the arguments directly through to the regular `add_source_files()`.

The return value allows the possibility of combining several folders into the same scu translation unit (which is more efficient). If this is desired it should be done by adding the extra folders in the master list in `scu_builders.py`.

3) Modification of a limited amount of the Godot source code where there are naming conflicts that would occur when compiling files in the same translation unit. This is usually due to conflicts within global namespace - static functions defined only within cpp files are often culprits.

Alternatively, these files can be excluded from the scu build in the master list in `scu_builders.py`, which will avoid the need for changing any source code. However this will result in slower SCU builds.
</details>

## Instructions
<details>
<summary>Instructions for users (contributors)</summary>

### Instructions for users (contributors)

1) Add `use_scu=yes` to your Scons args.
2) Make sure to compile with a non-scu (regular) build _prior_ to submitting PRs. This is because SCU builds by nature include headers from earlier cpps in the translation unit, therefore won't catch all the includes you will need in a regular build. The CI will catch these errors but it will usually be faster to catch them on a local build on your machine.
That's it. :smiley: 

`use_scu=yes` automatically runs `scu_builders.py` to generate the `scu` folders and `scu` generated files for different modules. It is rerun each time Scons is invoked, because if you are adding or removing files from the monitored folders the scu files must be regenerated (it's quite fast).
</details>

<details>
<summary>Instructions for regular build maintainers / contributors adding new folders</summary>

### Instructions for regular build maintainers / contributors adding new folders

1) For most SCsub files (outside core especially) continue to use `add_source_files()` as usual.
2) For the core folders that are already converted, try to keep the `add_source_files_scu()` versions for the main folders.

If you need to add new folders for compilation, either add an `SConscript` for the new folder `SCsub` file, or use `add_source_files()` as you normally would (but outside any `if` clause for the `add_source_files_scu()` command).
</details>

<details>
<summary>Instructions for SCU build maintenance</summary>

### Instructions for SCU build maintenance

1) Periodically a SCU build maintainer (presumably myself at least to start with) will make any small modifications to ensure the SCU build is optimizing as many folders as possible.
2) Occasionally PRs are expected to break the SCU build. This will be things like naming conflicts. This won't affect regular builds, but there will be occasional fixup PRs to either:
* Correct the naming conflict in the source code
* Exclude the files concerned from the SCU build (in `scu_builders.py`, these files can be marked as exceptions in the master list)

The master list contains entries like the following:
```
process_folder(["scene/3d"], ["baked_lightmap"], 2, "cpp")
```
The arguments are:
1) List of folders to be included in the translation unit. The first folder will be the folder that a `scu` subfolder is added to, and will determine the filename of the scu files. In most cases only a single folder will be in the list. Any more entries must be subfolders, relative to the first.
2) List of _exceptions_, filenames that will not be included in the scu translation unit. They will be compiled as separate cpps. This will prevent the speedup, but easily allows dealing with files that contain naming conflicts.
3) Number of translation units to employ. This will usually be 1, but can be increased to separate into groups, which will decrease the memory use by compiler processes.
4) Extension. Usually `cpp`, but can be `c` for e.g. third party libraries.

Only the first argument is required, the rest have defaults, and are rarely used.

It is highly likely I would maintain the SCU build to start with, but it is fairly simple to do, so any maintainer with an interest can keep it running well.
</details>

## Limitations
DEV builds only currently, because the compile instances use a lot more memory. This is ok in debug builds, but in optimized builds clang at least can use more than 2Gb so could run out of memory depending on the PC.

## Some benchmarks
<details>

I originally converted a lot more of the engine, but this version mainly involves just Godot core for simplicity. As such, full rebuilds aren't as fast as they can be, but touching important headers results in quite a bit faster compilation.

##### (Intel i5-7500T, 2.7ghz x 4, Linux Mint 20, SSD. i.e. low end CPU)
#### Full rebuild
Normal build 7mins 53
SCU build 3mins 41

#### Touching `node.h`
Normal build 4mins 10
SCU build 1min 42

With a fuller SCU conversion I had full rebuild down to 3 mins 3 (or 1 min 48 with `custom.py`), and touching `node.h` down to 1 min 30. However I'm not sure at this stage the maintenance cost was worth it as these were mostly thirdparty changes.
</details>

## Notes
* I'm not an expert in python by a long shot (in fact I had to look up `hello_world.py` just the other day :grin: ) so would probably need some good checking / fixing up of any python / Scons script.

#### ToDo
* Test on other OS (only tested on linux, so path slashes might need different on windows?). However this can be done in a followup PR, even just working on linux would be good to start, and I don't have access to windows machines.
* 
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
