### PR TITLE
Canvas item hierarchical culling

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1438,6 +1438,10 @@
 			[b]Experimental.[/b] If set to on, uses the [code]GL_STREAM_DRAW[/code] flag for legacy buffer uploads. If off, uses the [code]GL_DYNAMIC_DRAW[/code] flag.
 			[b]Note:[/b] Use with care. You are advised to leave this as default for exports. A non-default setting that works better on your machine may adversely affect performance for end users.
 		</member>
+		<member name="rendering/2d/options/culling_mode" type="int" setter="" getter="" default="1">
+			The culling mode determines the method used for rejecting canvas items that are outside a viewport. The visual result should be identical, but some modes may be faster for a particular project.
+			You can either cull items individually ([code]Item mode[/code]), or use hierarchical culling ([code]Node mode[/code]) which has a little more housekeeping but can increase performance by culling large numbers of items at once.
+		</member>
 		<member name="rendering/2d/options/ninepatch_mode" type="int" setter="" getter="" default="1">
 			Choose between fixed mode where corner scalings are preserved matching the artwork, and scaling mode.
 			Not available in GLES3 when [member rendering/batching/options/use_batching] is off.

--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -39,6 +39,7 @@
 #include "scene/resources/style_box.h"
 #include "scene/resources/texture.h"
 #include "scene/scene_string_names.h"
+#include "servers/visual/visual_server_constants.h"
 #include "servers/visual/visual_server_raster.h"
 #include "servers/visual_server.h"
 
@@ -615,6 +616,17 @@ void CanvasItem::_notification(int p_what) {
 		} break;
 	}
 }
+
+#ifdef DEV_ENABLED
+void CanvasItem::_name_changed_notify() {
+	// Even in DEV builds, there is no point in calling this unless we are debugging
+	// canvas item names. Even calling the stub function will be expensive, as there
+	// are a lot of canvas items.
+#ifdef VISUAL_SERVER_CANVAS_DEBUG_ITEM_NAMES
+	VisualServer::get_singleton()->canvas_item_set_name(canvas_item, get_name());
+#endif
+}
+#endif
 
 void CanvasItem::update() {
 	if (!is_inside_tree()) {

--- a/scene/2d/canvas_item.h
+++ b/scene/2d/canvas_item.h
@@ -240,6 +240,10 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
+#ifdef DEV_ENABLED
+	virtual void _name_changed_notify();
+#endif
+
 public:
 	enum {
 		NOTIFICATION_TRANSFORM_CHANGED = SceneTree::NOTIFICATION_TRANSFORM_CHANGED, //unique

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1051,7 +1051,15 @@ StringName Node::get_name() const {
 
 void Node::_set_name_nocheck(const StringName &p_name) {
 	data.name = p_name;
+#ifdef DEV_ENABLED
+	_name_changed_notify();
+#endif
 }
+
+#ifdef DEV_ENABLED
+void Node::_name_changed_notify() {
+}
+#endif
 
 void Node::set_name(const String &p_name) {
 	String name = p_name.validate_node_name();
@@ -1078,6 +1086,10 @@ void Node::set_name(const String &p_name) {
 		get_tree()->node_renamed(this);
 		get_tree()->tree_changed();
 	}
+
+#ifdef DEV_ENABLED
+	_name_changed_notify();
+#endif
 }
 
 static bool node_hrcr = false;
@@ -1262,7 +1274,7 @@ void Node::_generate_serial_child_name(const Node *p_child, StringName &name) co
 void Node::_add_child_nocheck(Node *p_child, const StringName &p_name) {
 	//add a child node quickly, without name validation
 
-	p_child->data.name = p_name;
+	p_child->_set_name_nocheck(p_name);
 	p_child->data.pos = data.children.size();
 	data.children.push_back(p_child);
 	p_child->data.parent = this;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -238,6 +238,9 @@ protected:
 	virtual void remove_child_notify(Node *p_child);
 	virtual void move_child_notify(Node *p_child);
 	virtual void owner_changed_notify();
+#ifdef DEV_ENABLED
+	virtual void _name_changed_notify();
+#endif
 
 	virtual void _physics_interpolated_changed();
 

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -956,6 +956,8 @@ public:
 		bool light_masked : 1;
 		mutable bool custom_rect : 1;
 		mutable bool rect_dirty : 1;
+		mutable bool xform_dirty : 1;
+		mutable bool bound_dirty : 1;
 
 		Vector<Command *> commands;
 		mutable Rect2 rect;
@@ -983,6 +985,10 @@ public:
 		ViewportRender *vp_render;
 
 		Rect2 global_rect_cache;
+
+		// the rect containing this item and all children,
+		// in local space.
+		Rect2 local_bound;
 
 		const Rect2 &get_rect() const {
 			if (custom_rect) {
@@ -1185,6 +1191,7 @@ public:
 			commands.clear();
 			clip = false;
 			rect_dirty = true;
+			xform_dirty = true;
 			final_clip_owner = nullptr;
 			material_owner = nullptr;
 			light_masked = false;
@@ -1199,6 +1206,8 @@ public:
 			final_modulate = Color(1, 1, 1, 1);
 			visible = true;
 			rect_dirty = true;
+			xform_dirty = true;
+			bound_dirty = true;
 			custom_rect = false;
 			behind = false;
 			material_owner = nullptr;

--- a/servers/visual/visual_server_canvas.cpp
+++ b/servers/visual/visual_server_canvas.cpp
@@ -39,7 +39,12 @@ void VisualServerCanvas::_render_canvas_item_tree(Item *p_canvas_item, const Tra
 	memset(z_list, 0, z_range * sizeof(RasterizerCanvas::Item *));
 	memset(z_last_list, 0, z_range * sizeof(RasterizerCanvas::Item *));
 
-	_render_canvas_item(p_canvas_item, p_transform, p_clip_rect, Color(1, 1, 1, 1), 0, z_list, z_last_list, nullptr, nullptr);
+	if (_canvas_cull_mode == CANVAS_CULL_MODE_NODE) {
+		_prepare_tree_bounds(p_canvas_item, p_transform);
+		_render_canvas_item_cull_by_node(p_canvas_item, p_transform, p_clip_rect, Color(1, 1, 1, 1), 0, z_list, z_last_list, nullptr, nullptr, false, nullptr, false);
+	} else {
+		_render_canvas_item_cull_by_item(p_canvas_item, p_transform, p_clip_rect, Color(1, 1, 1, 1), 0, z_list, z_last_list, nullptr, nullptr);
+	}
 
 	VSG::canvas_render->canvas_render_items_begin(p_modulate, p_lights, p_transform);
 	for (int i = 0; i < z_range; i++) {
@@ -85,7 +90,211 @@ void _mark_ysort_dirty(VisualServerCanvas::Item *ysort_owner, RID_Owner<VisualSe
 	} while (ysort_owner && ysort_owner->sort_y);
 }
 
-void VisualServerCanvas::_render_canvas_item(Item *p_canvas_item, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, int p_z, RasterizerCanvas::Item **z_list, RasterizerCanvas::Item **z_last_list, Item *p_canvas_clip, Item *p_material_owner) {
+void VisualServerCanvas::_make_bound_dirty_reparent(Item *p_item) {
+	MutexLock lock(_bound_mutex);
+	DEV_ASSERT(p_item);
+
+	Item *p_orig_item = p_item;
+
+	// propagate up
+	while (p_item) {
+		// Don't worry about invisible objects
+		if (!p_item->visible) {
+			return;
+		}
+
+		if (!p_item->bound_dirty) {
+			p_item->bound_dirty = true;
+
+			if (canvas_item_owner.owns(p_item->parent)) {
+				p_item = canvas_item_owner.get(p_item->parent);
+			} else {
+				break;
+			}
+		} else {
+			break;
+		}
+	}
+
+	// propagate down
+	_make_bound_dirty_down(p_orig_item);
+}
+
+void VisualServerCanvas::_make_bound_dirty(Item *p_item, bool p_changing_visibility) {
+	MutexLock lock(_bound_mutex);
+	DEV_ASSERT(p_item);
+
+	if (!p_changing_visibility) {
+		_check_bound_integrity(p_item);
+	}
+
+	if (!p_changing_visibility) {
+		// Traverse up the tree, making each item bound dirty until
+		// we reach an item that is already dirty (as by definition, if this happens,
+		// the tree should already be dirty up until the root).
+		while (p_item) {
+			// Don't worry about invisible objects
+			if (!p_item->visible) {
+				return;
+			}
+
+			if (!p_item->bound_dirty) {
+				p_item->bound_dirty = true;
+
+				if (canvas_item_owner.owns(p_item->parent)) {
+					p_item = canvas_item_owner.get(p_item->parent);
+				} else {
+					break;
+				}
+			} else {
+				break;
+			}
+		}
+	} else {
+		// special case for visibility changes.
+		// if hiding, we propagate upwards.
+		while (p_item) {
+			if (!p_item->bound_dirty) {
+				p_item->bound_dirty = true;
+			}
+
+			if (canvas_item_owner.owns(p_item->parent)) {
+				p_item = canvas_item_owner.get(p_item->parent);
+			} else {
+				break;
+			}
+		}
+
+		// if showing we propagate upwards AND downwards
+		if (p_item->visible) {
+			_make_bound_dirty_down(p_item);
+		}
+	}
+}
+
+void VisualServerCanvas::_make_bound_dirty_down(Item *p_item) {
+	// Bounds below an item that is being made visible may be out of date,
+	// so we make them all dirty.
+	if (!p_item->visible) {
+		return;
+	}
+
+	p_item->bound_dirty = true;
+
+	int child_item_count = p_item->child_items.size();
+	Item **child_items = p_item->child_items.ptrw();
+
+	for (int i = 0; i < child_item_count; i++) {
+		_make_bound_dirty_down(child_items[i]);
+	}
+}
+
+void VisualServerCanvas::_prepare_tree_bounds(Item *p_root, const Transform2D &p_transform) {
+	// See if the camera transform has changed, because if it has,
+	// we need to recalculate all global rects.
+	// Just changing the root node to dirty will be enough to force recalculation
+	// of the tree.
+	if (p_root && !p_root->xform_dirty) {
+		Transform2D xform = p_root->xform;
+		xform = p_transform * xform;
+		if (xform != p_root->final_transform) {
+			p_root->xform_dirty = true;
+		}
+	}
+
+	// For testing purposes, it can be possible to calculate bounds as a preprocess
+	// (rather than on the main _render_canvas_item() call). This can be used to verify
+	// the results between the two techniques of bound calculation - _calculate_canvas_item_bound()
+	// or _render_canvas_item(). The results should be the same in both cases.
+#if 0
+	Rect2 dummy_bound;
+	_calculate_canvas_item_bound(p_root, &dummy_bound);
+#endif
+}
+
+// This function provides an alternative means of recursively calculating canvas item
+// bounds through a branch, leading to an identical (hopefully) result to that
+// calculated for the bound in _render_canvas_item().
+// The reason for this function's existence is that there are some conditions which
+// prevent further drawing in the tree (such as alpha nearing 0.0), in which we
+// *still* need to calculate the bounds for lower branches and use them for culling,
+// just in case alpha increases above the threshold in a later frame.
+void VisualServerCanvas::_calculate_canvas_item_bound(Item *p_canvas_item, Rect2 *r_branch_bound) {
+	// TODO - this higher level technique may be able to be optimized better,
+	// to perhaps only recalculate this on "reappearance" of the child branch, in a
+	// similar manner to how visibility is handled.
+
+	Item *ci = p_canvas_item;
+
+	if (!ci->visible) {
+		return;
+	}
+
+	// easy case, not dirty
+	if (!ci->bound_dirty) {
+		_merge_local_bound_to_branch(ci, r_branch_bound);
+		return;
+	}
+
+	// recalculate the local bound only if out of date
+	Rect2 *local_bound = nullptr;
+	if (ci->bound_dirty) {
+		local_bound = &ci->local_bound;
+		*local_bound = Rect2();
+		ci->bound_dirty = false;
+	}
+
+	int child_item_count = ci->child_items.size();
+	Item **child_items = ci->child_items.ptrw();
+
+	for (int i = 0; i < child_item_count; i++) {
+		// if (ci->sort_y)
+		// NYI do we need to apply the child_items[i]->ysort_xform? TEST
+		// See the _render_canvas_item for how to apply.
+		_calculate_canvas_item_bound(child_items[i], local_bound);
+	}
+
+	_finalize_and_merge_local_bound_to_branch(ci, r_branch_bound);
+}
+
+void VisualServerCanvas::_finalize_and_merge_local_bound_to_branch(Item *p_canvas_item, Rect2 *r_branch_bound) {
+	if (r_branch_bound) {
+		Rect2 this_rect = p_canvas_item->get_rect();
+
+		if (!p_canvas_item->local_bound.has_no_area()) {
+			if (!this_rect.has_no_area()) {
+				p_canvas_item->local_bound = p_canvas_item->local_bound.merge(this_rect);
+			} else {
+				// Do nothing .. neither has any area.
+				// don't merge zero area, as it may expand the branch bound
+				// unnecessarily.
+				return;
+			}
+		} else {
+			p_canvas_item->local_bound = this_rect;
+		}
+
+		// merge the local bound
+		_merge_local_bound_to_branch(p_canvas_item, r_branch_bound);
+	}
+}
+
+void VisualServerCanvas::_merge_local_bound_to_branch(Item *p_canvas_item, Rect2 *r_branch_bound) {
+	if (!r_branch_bound) {
+		return;
+	}
+
+	Item *ci = p_canvas_item;
+	Rect2 this_item_total_local_bound = ci->xform.xform(ci->local_bound);
+
+	if (!r_branch_bound->has_no_area()) {
+		*r_branch_bound = r_branch_bound->merge(this_item_total_local_bound);
+	} else {
+		*r_branch_bound = this_item_total_local_bound;
+	}
+}
+
+void VisualServerCanvas::_render_canvas_item_cull_by_item(Item *p_canvas_item, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, int p_z, RasterizerCanvas::Item **z_list, RasterizerCanvas::Item **z_last_list, Item *p_canvas_clip, Item *p_material_owner) {
 	Item *ci = p_canvas_item;
 
 	if (!ci->visible) {
@@ -161,9 +370,9 @@ void VisualServerCanvas::_render_canvas_item(Item *p_canvas_item, const Transfor
 			continue;
 		}
 		if (ci->sort_y) {
-			_render_canvas_item(child_items[i], xform * child_items[i]->ysort_xform, p_clip_rect, modulate * child_items[i]->ysort_modulate, p_z, z_list, z_last_list, (Item *)ci->final_clip_owner, (Item *)child_items[i]->material_owner);
+			_render_canvas_item_cull_by_item(child_items[i], xform * child_items[i]->ysort_xform, p_clip_rect, modulate * child_items[i]->ysort_modulate, p_z, z_list, z_last_list, (Item *)ci->final_clip_owner, (Item *)child_items[i]->material_owner);
 		} else {
-			_render_canvas_item(child_items[i], xform, p_clip_rect, modulate, p_z, z_list, z_last_list, (Item *)ci->final_clip_owner, p_material_owner);
+			_render_canvas_item_cull_by_item(child_items[i], xform, p_clip_rect, modulate, p_z, z_list, z_last_list, (Item *)ci->final_clip_owner, p_material_owner);
 		}
 	}
 
@@ -202,11 +411,278 @@ void VisualServerCanvas::_render_canvas_item(Item *p_canvas_item, const Transfor
 			continue;
 		}
 		if (ci->sort_y) {
-			_render_canvas_item(child_items[i], xform * child_items[i]->ysort_xform, p_clip_rect, modulate * child_items[i]->ysort_modulate, p_z, z_list, z_last_list, (Item *)ci->final_clip_owner, (Item *)child_items[i]->material_owner);
+			_render_canvas_item_cull_by_item(child_items[i], xform * child_items[i]->ysort_xform, p_clip_rect, modulate * child_items[i]->ysort_modulate, p_z, z_list, z_last_list, (Item *)ci->final_clip_owner, (Item *)child_items[i]->material_owner);
 		} else {
-			_render_canvas_item(child_items[i], xform, p_clip_rect, modulate, p_z, z_list, z_last_list, (Item *)ci->final_clip_owner, p_material_owner);
+			_render_canvas_item_cull_by_item(child_items[i], xform, p_clip_rect, modulate, p_z, z_list, z_last_list, (Item *)ci->final_clip_owner, p_material_owner);
 		}
 	}
+}
+
+void VisualServerCanvas::_render_canvas_item_cull_by_node(Item *p_canvas_item, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, int p_z, RasterizerCanvas::Item **z_list, RasterizerCanvas::Item **z_last_list, Item *p_canvas_clip, Item *p_material_owner, bool p_update_global_rects, Rect2 *r_branch_bound, bool p_enclosed) {
+	Item *ci = p_canvas_item;
+
+	if (!ci->visible) {
+		return;
+	}
+
+	// If the caller is requesting the bounds to be calculated.
+	// The simplest case is handled here if the bound is not dirty.
+	if (r_branch_bound && !ci->bound_dirty) {
+		Rect2 this_item_total_local_bound = ci->xform.xform(ci->local_bound);
+
+		if (!r_branch_bound->has_no_area()) {
+			*r_branch_bound = r_branch_bound->merge(this_item_total_local_bound);
+		} else {
+			*r_branch_bound = this_item_total_local_bound;
+		}
+	}
+
+	Rect2 global_rect;
+	Transform2D xform;
+
+	bool xform_dirty = ci->xform_dirty;
+
+	// Cached global rects and transforms lets us eliminate this
+	// expensive step if the item and camera are not moving.
+	// In theory we should be able to cache item rects in world space
+	// even if the camera is moving, but this doesn't save us much,
+	// as in Godot currently the camera transform is applied BEFORE
+	// sending to the GPU.
+	// (It could still perhaps be used for culling against world space camera
+	// bounds .. investigate if time).
+	if (p_update_global_rects || xform_dirty || ci->rect_dirty) {
+		Rect2 rect = ci->get_rect();
+
+		xform = ci->xform;
+		xform = p_transform * xform;
+
+		global_rect = xform.xform(rect);
+
+		// We store the global rect and transform,
+		// irrespective of whether the item is being drawn,
+		// because it saves us calculating it again next time.
+		ci->global_rect_cache = global_rect;
+		ci->final_transform = xform;
+
+		// Hopefully this will be optimized to something sensible.
+		// We could just set the flag, but let the optimizer decide.
+		if (xform_dirty) {
+			ci->xform_dirty = false;
+		}
+
+		// update the global rects of any children, as they will be affected
+		p_update_global_rects = true;
+
+#ifdef DEV_ENABLED
+		_global_rects_calced++;
+#endif
+	} else {
+		// Read from cached versions
+		global_rect = ci->global_rect_cache;
+		xform = ci->final_transform;
+
+#ifdef VISUAL_SERVER_CANVAS_CHECK_BOUNDS
+		// Verify the cached version is same as ground truth result
+		Transform2D xform2 = ci->xform;
+		xform2 = p_transform * xform2;
+		DEV_ASSERT(xform2 == xform);
+
+		Rect2 global_rect2 = xform2.xform(ci->get_rect());
+		DEV_ASSERT(global_rect2 == global_rect);
+#endif
+
+#ifdef DEV_ENABLED
+		_global_rects_read++;
+#endif
+	}
+
+	global_rect.position += p_clip_rect.position;
+
+	int child_item_count = ci->child_items.size();
+
+	// if there are children, we can maybe cull them all out if the cached bound has not changed
+	if (!p_enclosed && !ci->bound_dirty && child_item_count) {
+		// get the bound in global space
+		Rect2 bound = xform.xform(ci->local_bound);
+		// print_line(String(Variant(ci->local_bound)) + " to " + String(Variant(bound)));
+
+		bound.position += p_clip_rect.position;
+		if (!ci->vp_render && !ci->copy_back_buffer) {
+			if (!p_clip_rect.intersects(bound, true)) {
+#ifdef VISUAL_SERVER_CANVAS_CHECK_BOUNDS
+				// This is a noop, except to calculate the test_bound used for the
+				// debugging check below.
+				Rect2 test_bound;
+				_calculate_canvas_item_bound(p_canvas_item, &test_bound);
+
+				if (!test_bound.has_no_area()) {
+					Rect2 test_comparison = ci->xform.xform(ci->local_bound);
+
+					if (test_bound != test_comparison) {
+						ERR_PRINT("bounds incorrect");
+
+						// repeat so we can debug through
+						//Rect2 test_bound;
+						//_calculate_canvas_item_bound(p_canvas_item, p_transform, &test_bound);
+					}
+				}
+#endif
+
+				return;
+			}
+		}
+
+		// can we combine with earlier check?
+		// if we enclose the bound completely, no need to check further children
+		p_enclosed = p_clip_rect.encloses(bound);
+	}
+
+	// If we are recalculating the bound, set a pointer to the local bound to calculate,
+	// and use this instead of the dirty flag from now on.
+	Rect2 *local_bound = nullptr;
+	if (ci->bound_dirty) {
+		local_bound = &ci->local_bound;
+		*local_bound = Rect2();
+		ci->bound_dirty = false;
+	}
+
+	// if we are culled, and no children, no more needs doing
+	bool item_is_visible = ((!ci->commands.empty() && (p_enclosed ? true : p_clip_rect.intersects(global_rect, true))) || ci->vp_render || ci->copy_back_buffer);
+	if (!item_is_visible && !child_item_count) {
+		// there is only this item, no children, so use the rect directly for a new bound
+		if (local_bound) {
+			*local_bound = ci->get_rect();
+		}
+
+		// Merge the local bound to the requested branch bound, if required
+		// N.B. possibly can be moved to the if statement above? As this may have already been done for non dirty items?
+		_merge_local_bound_to_branch(ci, r_branch_bound);
+		return;
+	}
+
+	if (ci->use_parent_material && p_material_owner) {
+		ci->material_owner = p_material_owner;
+	} else {
+		p_material_owner = ci;
+		ci->material_owner = nullptr;
+	}
+
+	Color modulate(ci->modulate.r * p_modulate.r, ci->modulate.g * p_modulate.g, ci->modulate.b * p_modulate.b, ci->modulate.a * p_modulate.a);
+
+	if (modulate.a < 0.007) {
+		// still may need to calculate the bounds if these are out of date,
+		// so the bounds hierarchy doesn't get corrupt
+		if (local_bound) {
+			_calculate_canvas_item_bound(p_canvas_item, local_bound);
+		}
+		// merge the local bound
+		_merge_local_bound_to_branch(ci, r_branch_bound);
+		return;
+	}
+
+	if (ci->children_order_dirty) {
+		ci->child_items.sort_custom<ItemIndexSort>();
+		ci->children_order_dirty = false;
+	}
+
+	Item **child_items = ci->child_items.ptrw();
+
+	if (ci->clip) {
+		if (p_canvas_clip != nullptr) {
+			ci->final_clip_rect = p_canvas_clip->final_clip_rect.clip(global_rect);
+		} else {
+			ci->final_clip_rect = global_rect;
+		}
+		ci->final_clip_rect.position = ci->final_clip_rect.position.round();
+		ci->final_clip_rect.size = ci->final_clip_rect.size.round();
+		ci->final_clip_owner = ci;
+
+	} else {
+		ci->final_clip_owner = p_canvas_clip;
+	}
+
+	if (ci->sort_y) {
+		if (ci->ysort_children_count == -1) {
+			ci->ysort_children_count = 0;
+			_collect_ysort_children(ci, Transform2D(), p_material_owner, Color(1, 1, 1, 1), nullptr, ci->ysort_children_count);
+		}
+
+		child_item_count = ci->ysort_children_count;
+
+		// NOTE : Use of alloca here in a recursive function could make it susceptible to stack overflow.
+		// This was present in the original Item code. Consider changing to make safer.
+		child_items = (Item **)alloca(child_item_count * sizeof(Item *));
+
+		int i = 0;
+		_collect_ysort_children(ci, Transform2D(), p_material_owner, Color(1, 1, 1, 1), child_items, i);
+
+		SortArray<Item *, ItemPtrSort> sorter;
+		sorter.sort(child_items, child_item_count);
+	}
+
+	if (ci->z_relative) {
+		p_z = CLAMP(p_z + ci->z_index, VS::CANVAS_ITEM_Z_MIN, VS::CANVAS_ITEM_Z_MAX);
+	} else {
+		p_z = ci->z_index;
+	}
+
+	for (int i = 0; i < child_item_count; i++) {
+		if (!child_items[i]->behind || (ci->sort_y && child_items[i]->sort_y)) {
+			continue;
+		}
+		if (ci->sort_y) {
+			_render_canvas_item_cull_by_node(child_items[i], xform * child_items[i]->ysort_xform, p_clip_rect, modulate * child_items[i]->ysort_modulate, p_z, z_list, z_last_list, (Item *)ci->final_clip_owner, (Item *)child_items[i]->material_owner, p_update_global_rects, local_bound, p_enclosed);
+		} else {
+			_render_canvas_item_cull_by_node(child_items[i], xform, p_clip_rect, modulate, p_z, z_list, z_last_list, (Item *)ci->final_clip_owner, p_material_owner, p_update_global_rects, local_bound, p_enclosed);
+		}
+	}
+
+	if (ci->copy_back_buffer) {
+		ci->copy_back_buffer->screen_rect = xform.xform(ci->copy_back_buffer->rect).clip(p_clip_rect);
+	}
+
+	// something to draw?
+	if (item_is_visible) {
+		// Note : This has been moved to inside the (item_is_visible) check.
+		// It was OUTSIDE in the item culled code, which I suspect was incorrect.
+		// A redraw should not be issued if an item is not on screen?
+		// Even so, watch for regressions here.
+		if (ci->update_when_visible) {
+			VisualServerRaster::redraw_request(false);
+		}
+
+		// Note we have already stored ci->final_transform
+		// and ci->global_rect_cache, and made sure these are up to date.
+		ci->final_modulate = Color(modulate.r * ci->self_modulate.r, modulate.g * ci->self_modulate.g, modulate.b * ci->self_modulate.b, modulate.a * ci->self_modulate.a);
+		ci->light_masked = false;
+
+		int zidx = p_z - VS::CANVAS_ITEM_Z_MIN;
+
+		if (z_last_list[zidx]) {
+			z_last_list[zidx]->next = ci;
+			z_last_list[zidx] = ci;
+
+		} else {
+			z_list[zidx] = ci;
+			z_last_list[zidx] = ci;
+		}
+
+		ci->next = nullptr;
+	}
+
+	for (int i = 0; i < child_item_count; i++) {
+		if (child_items[i]->behind || (ci->sort_y && child_items[i]->sort_y)) {
+			continue;
+		}
+		if (ci->sort_y) {
+			_render_canvas_item_cull_by_node(child_items[i], xform * child_items[i]->ysort_xform, p_clip_rect, modulate * child_items[i]->ysort_modulate, p_z, z_list, z_last_list, (Item *)ci->final_clip_owner, (Item *)child_items[i]->material_owner, p_update_global_rects, local_bound, p_enclosed);
+		} else {
+			_render_canvas_item_cull_by_node(child_items[i], xform, p_clip_rect, modulate, p_z, z_list, z_last_list, (Item *)ci->final_clip_owner, p_material_owner, p_update_global_rects, local_bound, p_enclosed);
+		}
+	}
+
+	// merge the local bound
+	_finalize_and_merge_local_bound_to_branch(ci, r_branch_bound);
 }
 
 void VisualServerCanvas::_light_mask_canvas_items(int p_z, RasterizerCanvas::Item *p_canvas_item, RasterizerCanvas::Light *p_masked_lights, int p_canvas_layer_id) {
@@ -253,9 +729,52 @@ void VisualServerCanvas::render_canvas(Canvas *p_canvas, const Transform2D &p_tr
 		memset(z_list, 0, z_range * sizeof(RasterizerCanvas::Item *));
 		memset(z_last_list, 0, z_range * sizeof(RasterizerCanvas::Item *));
 
-		for (int i = 0; i < l; i++) {
-			_render_canvas_item(ci[i].item, p_transform, p_clip_rect, Color(1, 1, 1, 1), 0, z_list, z_last_list, nullptr, nullptr);
-		}
+#ifdef VISUAL_SERVER_CANVAS_TIME_NODE_CULLING
+		bool measure = (Engine::get_singleton()->get_frames_drawn() % 100) == 0;
+		measure &= !Engine::get_singleton()->is_editor_hint();
+
+		if (measure) {
+			uint64_t totalA = 0;
+			uint64_t totalB = 0;
+
+			for (int i = 0; i < l; i++) {
+				uint64_t beforeB = OS::get_singleton()->get_ticks_usec();
+				_render_canvas_item_cull_by_item(ci[i].item, p_transform, p_clip_rect, Color(1, 1, 1, 1), 0, z_list, z_last_list, nullptr, nullptr);
+				uint64_t afterB = OS::get_singleton()->get_ticks_usec();
+
+				uint64_t beforeA = OS::get_singleton()->get_ticks_usec();
+				_prepare_tree_bounds(ci[i].item, p_transform);
+				_render_canvas_item_cull_by_node(ci[i].item, p_transform, p_clip_rect, Color(1, 1, 1, 1), 0, z_list, z_last_list, nullptr, nullptr, false, nullptr, false);
+				uint64_t afterA = OS::get_singleton()->get_ticks_usec();
+
+				totalA += afterA - beforeA;
+				totalB += afterB - beforeB;
+
+			} // for i
+
+			print_line("old : " + itos(totalB) + ", new : " + itos(totalA));
+#ifdef DEV_ENABLED
+			print_line("global rects calced: " + itos(_global_rects_calced) + ", read: " + itos(_global_rects_read));
+			_global_rects_calced = 0;
+			_global_rects_read = 0;
+#endif
+
+		} // if measure
+		else {
+#else
+		{
+#endif
+			if (_canvas_cull_mode == CANVAS_CULL_MODE_NODE) {
+				for (int i = 0; i < l; i++) {
+					_prepare_tree_bounds(ci[i].item, p_transform);
+					_render_canvas_item_cull_by_node(ci[i].item, p_transform, p_clip_rect, Color(1, 1, 1, 1), 0, z_list, z_last_list, nullptr, nullptr, false, nullptr, false);
+				}
+			} else {
+				for (int i = 0; i < l; i++) {
+					_render_canvas_item_cull_by_item(ci[i].item, p_transform, p_clip_rect, Color(1, 1, 1, 1), 0, z_list, z_last_list, nullptr, nullptr);
+				}
+			}
+		} // if not measure
 
 		VSG::canvas_render->canvas_render_items_begin(p_canvas->modulate, p_lights, p_transform);
 		for (int i = 0; i < z_range; i++) {
@@ -337,9 +856,20 @@ RID VisualServerCanvas::canvas_item_create() {
 	return canvas_item_owner.make_rid(canvas_item);
 }
 
+void VisualServerCanvas::canvas_item_set_name(RID p_item, String p_name) {
+#ifdef VISUAL_SERVER_CANVAS_DEBUG_ITEM_NAMES
+	Item *canvas_item = canvas_item_owner.getornull(p_item);
+	ERR_FAIL_COND(!canvas_item);
+	canvas_item->name = p_name;
+#endif
+}
+
 void VisualServerCanvas::canvas_item_set_parent(RID p_item, RID p_parent) {
 	Item *canvas_item = canvas_item_owner.getornull(p_item);
 	ERR_FAIL_COND(!canvas_item);
+
+	// dirty the item and any previous parents
+	_make_bound_dirty(canvas_item);
 
 	if (canvas_item->parent.is_valid()) {
 		if (canvas_owner.owns(canvas_item->parent)) {
@@ -364,6 +894,8 @@ void VisualServerCanvas::canvas_item_set_parent(RID p_item, RID p_parent) {
 			ci.item = canvas_item;
 			canvas->child_items.push_back(ci);
 			canvas->children_order_dirty = true;
+
+			_make_bound_dirty(canvas_item);
 		} else if (canvas_item_owner.owns(p_parent)) {
 			Item *item_owner = canvas_item_owner.get(p_parent);
 			item_owner->child_items.push_back(canvas_item);
@@ -373,19 +905,31 @@ void VisualServerCanvas::canvas_item_set_parent(RID p_item, RID p_parent) {
 				_mark_ysort_dirty(item_owner, canvas_item_owner);
 			}
 
+			// keep the integrity of the bounds when adding to avoid false
+			// warning flags, by forcing the added child to be dirty
+			canvas_item->bound_dirty = false;
+			canvas_item->parent = p_parent;
+			_make_bound_dirty_reparent(canvas_item);
 		} else {
 			ERR_FAIL_MSG("Invalid parent.");
 		}
 	}
 
 	canvas_item->parent = p_parent;
+
+	_check_bound_integrity(canvas_item);
 }
 void VisualServerCanvas::canvas_item_set_visible(RID p_item, bool p_visible) {
 	Item *canvas_item = canvas_item_owner.getornull(p_item);
 	ERR_FAIL_COND(!canvas_item);
 
-	canvas_item->visible = p_visible;
+	// check for noop
+	if (p_visible != canvas_item->visible) {
+		canvas_item->visible = p_visible;
+		_make_bound_dirty(canvas_item, true);
+	}
 
+	// could this be enclosed in the noop? not sure
 	_mark_ysort_dirty(canvas_item, canvas_item_owner);
 }
 void VisualServerCanvas::canvas_item_set_light_mask(RID p_item, int p_mask) {
@@ -393,6 +937,7 @@ void VisualServerCanvas::canvas_item_set_light_mask(RID p_item, int p_mask) {
 	ERR_FAIL_COND(!canvas_item);
 
 	canvas_item->light_mask = p_mask;
+	_check_bound_integrity(canvas_item);
 }
 
 void VisualServerCanvas::canvas_item_set_transform(RID p_item, const Transform2D &p_transform) {
@@ -400,18 +945,29 @@ void VisualServerCanvas::canvas_item_set_transform(RID p_item, const Transform2D
 	ERR_FAIL_COND(!canvas_item);
 
 	canvas_item->xform = p_transform;
+	canvas_item->xform_dirty = true;
+
+	// Special case!
+	// Modifying the transform DOES NOT affect the local bound.
+	// It only affects the local bound of the PARENT node (if there is one).
+	if (canvas_item_owner.owns(canvas_item->parent)) {
+		Item *canvas_item_parent = canvas_item_owner.get(canvas_item->parent);
+		_make_bound_dirty(canvas_item_parent);
+	}
 }
 void VisualServerCanvas::canvas_item_set_clip(RID p_item, bool p_clip) {
 	Item *canvas_item = canvas_item_owner.getornull(p_item);
 	ERR_FAIL_COND(!canvas_item);
 
 	canvas_item->clip = p_clip;
+	_make_bound_dirty(canvas_item);
 }
 void VisualServerCanvas::canvas_item_set_distance_field_mode(RID p_item, bool p_enable) {
 	Item *canvas_item = canvas_item_owner.getornull(p_item);
 	ERR_FAIL_COND(!canvas_item);
 
 	canvas_item->distance_field = p_enable;
+	_make_bound_dirty(canvas_item);
 }
 void VisualServerCanvas::canvas_item_set_custom_rect(RID p_item, bool p_custom_rect, const Rect2 &p_rect) {
 	Item *canvas_item = canvas_item_owner.getornull(p_item);
@@ -419,18 +975,21 @@ void VisualServerCanvas::canvas_item_set_custom_rect(RID p_item, bool p_custom_r
 
 	canvas_item->custom_rect = p_custom_rect;
 	canvas_item->rect = p_rect;
+	_make_bound_dirty(canvas_item);
 }
 void VisualServerCanvas::canvas_item_set_modulate(RID p_item, const Color &p_color) {
 	Item *canvas_item = canvas_item_owner.getornull(p_item);
 	ERR_FAIL_COND(!canvas_item);
 
 	canvas_item->modulate = p_color;
+	_make_bound_dirty(canvas_item);
 }
 void VisualServerCanvas::canvas_item_set_self_modulate(RID p_item, const Color &p_color) {
 	Item *canvas_item = canvas_item_owner.getornull(p_item);
 	ERR_FAIL_COND(!canvas_item);
 
 	canvas_item->self_modulate = p_color;
+	_make_bound_dirty(canvas_item);
 }
 
 void VisualServerCanvas::canvas_item_set_draw_behind_parent(RID p_item, bool p_enable) {
@@ -438,6 +997,7 @@ void VisualServerCanvas::canvas_item_set_draw_behind_parent(RID p_item, bool p_e
 	ERR_FAIL_COND(!canvas_item);
 
 	canvas_item->behind = p_enable;
+	_check_bound_integrity(canvas_item);
 }
 
 void VisualServerCanvas::canvas_item_set_update_when_visible(RID p_item, bool p_update) {
@@ -445,6 +1005,7 @@ void VisualServerCanvas::canvas_item_set_update_when_visible(RID p_item, bool p_
 	ERR_FAIL_COND(!canvas_item);
 
 	canvas_item->update_when_visible = p_update;
+	_check_bound_integrity(canvas_item);
 }
 
 void VisualServerCanvas::canvas_item_add_line(RID p_item, const Point2 &p_from, const Point2 &p_to, const Color &p_color, float p_width, bool p_antialiased) {
@@ -504,6 +1065,7 @@ void VisualServerCanvas::canvas_item_add_line(RID p_item, const Point2 &p_from, 
 	canvas_item->rect_dirty = true;
 
 	canvas_item->commands.push_back(line);
+	_make_bound_dirty(canvas_item);
 }
 
 void VisualServerCanvas::canvas_item_add_polyline(RID p_item, const Vector<Point2> &p_points, const Vector<Color> &p_colors, float p_width, bool p_antialiased) {
@@ -586,6 +1148,7 @@ void VisualServerCanvas::canvas_item_add_polyline(RID p_item, const Vector<Point
 	}
 	canvas_item->rect_dirty = true;
 	canvas_item->commands.push_back(pline);
+	_make_bound_dirty(canvas_item);
 }
 
 void VisualServerCanvas::canvas_item_add_multiline(RID p_item, const Vector<Point2> &p_points, const Vector<Color> &p_colors, float p_width, bool p_antialiased) {
@@ -609,6 +1172,7 @@ void VisualServerCanvas::canvas_item_add_multiline(RID p_item, const Vector<Poin
 
 	canvas_item->rect_dirty = true;
 	canvas_item->commands.push_back(pline);
+	_make_bound_dirty(canvas_item);
 }
 
 void VisualServerCanvas::canvas_item_add_rect(RID p_item, const Rect2 &p_rect, const Color &p_color) {
@@ -622,6 +1186,7 @@ void VisualServerCanvas::canvas_item_add_rect(RID p_item, const Rect2 &p_rect, c
 	canvas_item->rect_dirty = true;
 
 	canvas_item->commands.push_back(rect);
+	_make_bound_dirty(canvas_item);
 }
 
 void VisualServerCanvas::canvas_item_add_circle(RID p_item, const Point2 &p_pos, float p_radius, const Color &p_color) {
@@ -635,6 +1200,7 @@ void VisualServerCanvas::canvas_item_add_circle(RID p_item, const Point2 &p_pos,
 	circle->radius = p_radius;
 
 	canvas_item->commands.push_back(circle);
+	_make_bound_dirty(canvas_item);
 }
 
 void VisualServerCanvas::canvas_item_add_texture_rect(RID p_item, const Rect2 &p_rect, RID p_texture, bool p_tile, const Color &p_modulate, bool p_transpose, RID p_normal_map) {
@@ -668,6 +1234,7 @@ void VisualServerCanvas::canvas_item_add_texture_rect(RID p_item, const Rect2 &p
 	rect->normal_map = p_normal_map;
 	canvas_item->rect_dirty = true;
 	canvas_item->commands.push_back(rect);
+	_make_bound_dirty(canvas_item);
 }
 
 void VisualServerCanvas::canvas_item_add_texture_rect_region(RID p_item, const Rect2 &p_rect, RID p_texture, const Rect2 &p_src_rect, const Color &p_modulate, bool p_transpose, RID p_normal_map, bool p_clip_uv) {
@@ -712,6 +1279,7 @@ void VisualServerCanvas::canvas_item_add_texture_rect_region(RID p_item, const R
 	canvas_item->rect_dirty = true;
 
 	canvas_item->commands.push_back(rect);
+	_make_bound_dirty(canvas_item);
 }
 
 void VisualServerCanvas::canvas_item_add_nine_patch(RID p_item, const Rect2 &p_rect, const Rect2 &p_source, RID p_texture, const Vector2 &p_topleft, const Vector2 &p_bottomright, VS::NinePatchAxisMode p_x_axis_mode, VS::NinePatchAxisMode p_y_axis_mode, bool p_draw_center, const Color &p_modulate, RID p_normal_map) {
@@ -735,6 +1303,7 @@ void VisualServerCanvas::canvas_item_add_nine_patch(RID p_item, const Rect2 &p_r
 	canvas_item->rect_dirty = true;
 
 	canvas_item->commands.push_back(style);
+	_make_bound_dirty(canvas_item);
 }
 void VisualServerCanvas::canvas_item_add_primitive(RID p_item, const Vector<Point2> &p_points, const Vector<Color> &p_colors, const Vector<Point2> &p_uvs, RID p_texture, float p_width, RID p_normal_map) {
 	Item *canvas_item = canvas_item_owner.getornull(p_item);
@@ -751,6 +1320,7 @@ void VisualServerCanvas::canvas_item_add_primitive(RID p_item, const Vector<Poin
 	canvas_item->rect_dirty = true;
 
 	canvas_item->commands.push_back(prim);
+	_make_bound_dirty(canvas_item);
 }
 
 void VisualServerCanvas::canvas_item_add_polygon(RID p_item, const Vector<Point2> &p_points, const Vector<Color> &p_colors, const Vector<Point2> &p_uvs, RID p_texture, RID p_normal_map, bool p_antialiased) {
@@ -781,6 +1351,7 @@ void VisualServerCanvas::canvas_item_add_polygon(RID p_item, const Vector<Point2
 	canvas_item->rect_dirty = true;
 
 	canvas_item->commands.push_back(polygon);
+	_make_bound_dirty(canvas_item);
 }
 
 void VisualServerCanvas::canvas_item_add_triangle_array(RID p_item, const Vector<int> &p_indices, const Vector<Point2> &p_points, const Vector<Color> &p_colors, const Vector<Point2> &p_uvs, const Vector<int> &p_bones, const Vector<float> &p_weights, RID p_texture, int p_count, RID p_normal_map, bool p_antialiased, bool p_antialiasing_use_indices) {
@@ -826,6 +1397,7 @@ void VisualServerCanvas::canvas_item_add_triangle_array(RID p_item, const Vector
 	canvas_item->rect_dirty = true;
 
 	canvas_item->commands.push_back(polygon);
+	_make_bound_dirty(canvas_item);
 }
 
 void VisualServerCanvas::canvas_item_add_set_transform(RID p_item, const Transform2D &p_transform) {
@@ -837,6 +1409,7 @@ void VisualServerCanvas::canvas_item_add_set_transform(RID p_item, const Transfo
 	tr->xform = p_transform;
 
 	canvas_item->commands.push_back(tr);
+	_make_bound_dirty(canvas_item);
 }
 
 void VisualServerCanvas::canvas_item_add_mesh(RID p_item, const RID &p_mesh, const Transform2D &p_transform, const Color &p_modulate, RID p_texture, RID p_normal_map) {
@@ -852,6 +1425,7 @@ void VisualServerCanvas::canvas_item_add_mesh(RID p_item, const RID &p_mesh, con
 	m->modulate = p_modulate;
 
 	canvas_item->commands.push_back(m);
+	_make_bound_dirty(canvas_item);
 }
 void VisualServerCanvas::canvas_item_add_particles(RID p_item, RID p_particles, RID p_texture, RID p_normal) {
 	Item *canvas_item = canvas_item_owner.getornull(p_item);
@@ -868,6 +1442,7 @@ void VisualServerCanvas::canvas_item_add_particles(RID p_item, RID p_particles, 
 
 	canvas_item->rect_dirty = true;
 	canvas_item->commands.push_back(part);
+	_make_bound_dirty(canvas_item);
 }
 
 void VisualServerCanvas::canvas_item_add_multimesh(RID p_item, RID p_mesh, RID p_texture, RID p_normal_map) {
@@ -882,6 +1457,7 @@ void VisualServerCanvas::canvas_item_add_multimesh(RID p_item, RID p_mesh, RID p
 
 	canvas_item->rect_dirty = true;
 	canvas_item->commands.push_back(mm);
+	_make_bound_dirty(canvas_item);
 }
 
 void VisualServerCanvas::canvas_item_add_clip_ignore(RID p_item, bool p_ignore) {
@@ -893,6 +1469,7 @@ void VisualServerCanvas::canvas_item_add_clip_ignore(RID p_item, bool p_ignore) 
 	ci->ignore = p_ignore;
 
 	canvas_item->commands.push_back(ci);
+	_make_bound_dirty(canvas_item);
 }
 void VisualServerCanvas::canvas_item_set_sort_children_by_y(RID p_item, bool p_enable) {
 	Item *canvas_item = canvas_item_owner.getornull(p_item);
@@ -901,6 +1478,7 @@ void VisualServerCanvas::canvas_item_set_sort_children_by_y(RID p_item, bool p_e
 	canvas_item->sort_y = p_enable;
 
 	_mark_ysort_dirty(canvas_item, canvas_item_owner);
+	_check_bound_integrity(canvas_item);
 }
 void VisualServerCanvas::canvas_item_set_z_index(RID p_item, int p_z) {
 	ERR_FAIL_COND(p_z < VS::CANVAS_ITEM_Z_MIN || p_z > VS::CANVAS_ITEM_Z_MAX);
@@ -909,12 +1487,14 @@ void VisualServerCanvas::canvas_item_set_z_index(RID p_item, int p_z) {
 	ERR_FAIL_COND(!canvas_item);
 
 	canvas_item->z_index = p_z;
+	_check_bound_integrity(canvas_item);
 }
 void VisualServerCanvas::canvas_item_set_z_as_relative_to_parent(RID p_item, bool p_enable) {
 	Item *canvas_item = canvas_item_owner.getornull(p_item);
 	ERR_FAIL_COND(!canvas_item);
 
 	canvas_item->z_relative = p_enable;
+	_check_bound_integrity(canvas_item);
 }
 
 void VisualServerCanvas::canvas_item_attach_skeleton(RID p_item, RID p_skeleton) {
@@ -922,6 +1502,7 @@ void VisualServerCanvas::canvas_item_attach_skeleton(RID p_item, RID p_skeleton)
 	ERR_FAIL_COND(!canvas_item);
 
 	canvas_item->skeleton = p_skeleton;
+	_make_bound_dirty(canvas_item);
 }
 
 void VisualServerCanvas::canvas_item_set_copy_to_backbuffer(RID p_item, bool p_enable, const Rect2 &p_rect) {
@@ -940,12 +1521,14 @@ void VisualServerCanvas::canvas_item_set_copy_to_backbuffer(RID p_item, bool p_e
 		canvas_item->copy_back_buffer->rect = p_rect;
 		canvas_item->copy_back_buffer->full = p_rect == Rect2();
 	}
+	_make_bound_dirty(canvas_item);
 }
 
 void VisualServerCanvas::canvas_item_clear(RID p_item) {
 	Item *canvas_item = canvas_item_owner.getornull(p_item);
 	ERR_FAIL_COND(!canvas_item);
 
+	_make_bound_dirty(canvas_item);
 	canvas_item->clear();
 }
 void VisualServerCanvas::canvas_item_set_draw_index(RID p_item, int p_index) {
@@ -965,6 +1548,7 @@ void VisualServerCanvas::canvas_item_set_draw_index(RID p_item, int p_index) {
 		canvas->children_order_dirty = true;
 		return;
 	}
+	_check_bound_integrity(canvas_item);
 }
 
 void VisualServerCanvas::canvas_item_set_material(RID p_item, RID p_material) {
@@ -972,6 +1556,7 @@ void VisualServerCanvas::canvas_item_set_material(RID p_item, RID p_material) {
 	ERR_FAIL_COND(!canvas_item);
 
 	canvas_item->material = p_material;
+	_make_bound_dirty(canvas_item);
 }
 
 void VisualServerCanvas::canvas_item_set_use_parent_material(RID p_item, bool p_enable) {
@@ -979,6 +1564,7 @@ void VisualServerCanvas::canvas_item_set_use_parent_material(RID p_item, bool p_
 	ERR_FAIL_COND(!canvas_item);
 
 	canvas_item->use_parent_material = p_enable;
+	_make_bound_dirty(canvas_item);
 }
 
 RID VisualServerCanvas::canvas_light_create() {
@@ -1320,6 +1906,7 @@ bool VisualServerCanvas::free(RID p_rid) {
 	} else if (canvas_item_owner.owns(p_rid)) {
 		Item *canvas_item = canvas_item_owner.get(p_rid);
 		ERR_FAIL_COND_V(!canvas_item, true);
+		_make_bound_dirty(canvas_item);
 
 		if (canvas_item->parent.is_valid()) {
 			if (canvas_owner.owns(canvas_item->parent)) {
@@ -1332,6 +1919,7 @@ bool VisualServerCanvas::free(RID p_rid) {
 				if (item_owner->sort_y) {
 					_mark_ysort_dirty(item_owner, canvas_item_owner);
 				}
+				_check_bound_integrity(item_owner);
 			}
 		}
 
@@ -1407,11 +1995,120 @@ bool VisualServerCanvas::free(RID p_rid) {
 	return true;
 }
 
+#ifdef VISUAL_SERVER_CANVAS_CHECK_BOUNDS
+// Debugging function to check that the bound dirty flags in the tree make sense.
+// Any item that has is dirty, all parents should be dirty up to the root
+// (except in hidden branches, which are not kept track of for performance reasons).
+bool VisualServerCanvas::_check_bound_integrity(const Item *p_item) {
+	while (p_item) {
+		if (canvas_item_owner.owns(p_item->parent)) {
+			p_item = canvas_item_owner.get(p_item->parent);
+		} else {
+			return _check_bound_integrity_down(p_item, p_item->bound_dirty);
+		}
+	}
+
+	return true;
+}
+
+bool VisualServerCanvas::_check_bound_integrity_down(const Item *p_item, bool p_bound_dirty) {
+	// don't care about integrity into invisible branches
+	if (!p_item->visible) {
+		return true;
+	}
+
+	if (p_item->bound_dirty) {
+		if (!p_bound_dirty) {
+			_print_tree(p_item);
+			ERR_PRINT("bound integrity check failed");
+			return false;
+		}
+	}
+
+	// go through children
+	int child_item_count = p_item->child_items.size();
+	Item *const *child_items = p_item->child_items.ptr();
+
+	for (int n = 0; n < child_item_count; n++) {
+		if (!_check_bound_integrity_down(child_items[n], p_bound_dirty)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+void VisualServerCanvas::_print_tree(const Item *p_item) {
+	const Item *highlight = p_item;
+
+	while (p_item) {
+		if (canvas_item_owner.owns(p_item->parent)) {
+			p_item = canvas_item_owner.get(p_item->parent);
+		} else {
+			_print_tree_down(0, 0, p_item, highlight);
+			return;
+		}
+	}
+}
+
+void VisualServerCanvas::_print_tree_down(int p_child_id, int p_depth, const Item *p_item, const Item *p_highlight, bool p_hidden) {
+	String sz;
+	for (int n = 0; n < p_depth; n++) {
+		sz += "\t";
+	}
+	if (p_item == p_highlight) {
+		sz += "* ";
+	}
+	sz += itos(p_child_id) + " ";
+#ifdef VISUAL_SERVER_CANVAS_DEBUG_ITEM_NAMES
+	sz += p_item->name + "\t";
+#endif
+	sz += String(Variant(p_item->global_rect_cache)) + " ";
+
+	if (!p_item->visible) {
+		sz += "(H) ";
+		p_hidden = true;
+	} else if (p_hidden) {
+		sz += "(HI) ";
+	}
+
+	if (p_item->bound_dirty) {
+		sz += "(dirty) ";
+	}
+
+	if (p_item->parent == RID()) {
+		sz += "(parent NULL) ";
+	}
+
+	print_line(sz);
+
+	// go through children
+	int child_item_count = p_item->child_items.size();
+	Item *const *child_items = p_item->child_items.ptr();
+
+	for (int n = 0; n < child_item_count; n++) {
+		_print_tree_down(n, p_depth + 1, child_items[n], p_highlight, p_hidden);
+	}
+}
+
+#endif
+
 VisualServerCanvas::VisualServerCanvas() {
 	z_list = (RasterizerCanvas::Item **)memalloc(z_range * sizeof(RasterizerCanvas::Item *));
 	z_last_list = (RasterizerCanvas::Item **)memalloc(z_range * sizeof(RasterizerCanvas::Item *));
 
 	disable_scale = false;
+
+	int mode = GLOBAL_DEF("rendering/2d/options/culling_mode", 1);
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/2d/options/culling_mode", PropertyInfo(Variant::INT, "rendering/2d/options/culling_mode", PROPERTY_HINT_ENUM, "Item,Node"));
+
+	switch (mode) {
+		default: {
+			_canvas_cull_mode = CANVAS_CULL_MODE_NODE;
+		} break;
+		case 0: {
+			_canvas_cull_mode = CANVAS_CULL_MODE_ITEM;
+		} break;
+	}
 }
 
 VisualServerCanvas::~VisualServerCanvas() {

--- a/servers/visual/visual_server_canvas.h
+++ b/servers/visual/visual_server_canvas.h
@@ -32,6 +32,7 @@
 #define VISUAL_SERVER_CANVAS_H
 
 #include "rasterizer.h"
+#include "visual_server_constants.h"
 #include "visual_server_viewport.h"
 
 class VisualServerCanvas {
@@ -52,6 +53,9 @@ public:
 		Transform2D ysort_xform;
 		Vector2 ysort_pos;
 		int ysort_index;
+#ifdef VISUAL_SERVER_CANVAS_DEBUG_ITEM_NAMES
+		String name;
+#endif
 
 		Vector<Item *> child_items;
 
@@ -154,12 +158,54 @@ public:
 	bool disable_scale;
 
 private:
+	enum CanvasCullMode {
+		CANVAS_CULL_MODE_ITEM,
+		CANVAS_CULL_MODE_NODE,
+	};
+	CanvasCullMode _canvas_cull_mode = CANVAS_CULL_MODE_NODE;
+
 	void _render_canvas_item_tree(Item *p_canvas_item, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, RasterizerCanvas::Light *p_lights);
-	void _render_canvas_item(Item *p_canvas_item, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, int p_z, RasterizerCanvas::Item **z_list, RasterizerCanvas::Item **z_last_list, Item *p_canvas_clip, Item *p_material_owner);
+
 	void _light_mask_canvas_items(int p_z, RasterizerCanvas::Item *p_canvas_item, RasterizerCanvas::Light *p_masked_lights, int p_canvas_layer_id);
 
 	RasterizerCanvas::Item **z_list;
 	RasterizerCanvas::Item **z_last_list;
+
+	// 3.5 and earlier had no hierarchical culling.
+	void _render_canvas_item_cull_by_item(Item *p_canvas_item, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, int p_z, RasterizerCanvas::Item **z_list, RasterizerCanvas::Item **z_last_list, Item *p_canvas_clip, Item *p_material_owner);
+
+	// Hierarchical culling by scene tree node ///////////////////////////////////
+	void _render_canvas_item_cull_by_node(Item *p_canvas_item, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, int p_z, RasterizerCanvas::Item **z_list, RasterizerCanvas::Item **z_last_list, Item *p_canvas_clip, Item *p_material_owner, bool p_update_global_rects, Rect2 *r_branch_bound, bool p_enclosed);
+
+	void _prepare_tree_bounds(Item *p_root, const Transform2D &p_transform);
+	void _calculate_canvas_item_bound(Item *p_canvas_item, Rect2 *r_branch_bound);
+
+	void _finalize_and_merge_local_bound_to_branch(Item *p_canvas_item, Rect2 *r_branch_bound);
+	void _merge_local_bound_to_branch(Item *p_canvas_item, Rect2 *r_branch_bound);
+
+	// If bounds flags are attempted to be modified multithreaded, the
+	// tree could become corrupt. Multithread access may not be possible,
+	// but just in case we use a mutex until proven otherwise.
+	Mutex _bound_mutex;
+#ifdef DEV_ENABLED
+	// Just some stats, useful for debugging
+	uint64_t _global_rects_calced = 0;
+	uint64_t _global_rects_read = 0;
+#endif
+
+	void _make_bound_dirty_reparent(Item *p_item);
+	void _make_bound_dirty(Item *p_item, bool p_changing_visibility = false);
+	void _make_bound_dirty_down(Item *p_item);
+
+#ifdef VISUAL_SERVER_CANVAS_CHECK_BOUNDS
+	bool _check_bound_integrity(const Item *p_item);
+	bool _check_bound_integrity_down(const Item *p_item, bool p_bound_dirty);
+	void _print_tree(const Item *p_item);
+	void _print_tree_down(int p_child_id, int p_depth, const Item *p_item, const Item *p_highlight, bool p_hidden = false);
+#else
+	bool _check_bound_integrity(const Item *p_item) { return true; }
+#endif
+	//////////////////////////////////////////////////////////////////////////////
 
 public:
 	void render_canvas(Canvas *p_canvas, const Transform2D &p_transform, RasterizerCanvas::Light *p_lights, RasterizerCanvas::Light *p_masked_lights, const Rect2 &p_clip_rect, int p_canvas_layer_id);
@@ -172,6 +218,7 @@ public:
 
 	RID canvas_item_create();
 	void canvas_item_set_parent(RID p_item, RID p_parent);
+	void canvas_item_set_name(RID p_item, String p_name);
 
 	void canvas_item_set_visible(RID p_item, bool p_visible);
 	void canvas_item_set_light_mask(RID p_item, int p_mask);

--- a/servers/visual/visual_server_constants.h
+++ b/servers/visual/visual_server_constants.h
@@ -1,0 +1,58 @@
+/*************************************************************************/
+/*  visual_server_constants.h                                            */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef VISUAL_SERVER_CONSTANTS_H
+#define VISUAL_SERVER_CONSTANTS_H
+
+// Use for constants etc that need not be included as often as VisualServer.h
+// to reduce dependencies and prevent slow compilation.
+
+// This is a "cheap" include, and can be used from scene side code as well as servers.
+
+// Uncomment to provide comparison of node culling versus item culling
+// #define VISUAL_SERVER_CANVAS_TIME_NODE_CULLING
+
+// N.B. ONLY allow these defined in DEV_ENABLED builds, they will slow
+// performance, and are only necessary to use for debugging.
+#ifdef DEV_ENABLED
+
+// Uncomment this define to store canvas item names in VisualServerCanvas.
+// This is relatively expensive, but is invaluable for debugging the canvas scene tree
+// especially using _print_tree() in VisualServerCanvas.
+// #define VISUAL_SERVER_CANVAS_DEBUG_ITEM_NAMES
+
+// Uncomment this define to verify local bounds of canvas items,
+// to check that the hierarchical culling is working correctly.
+// This is expensive.
+// #define VISUAL_SERVER_CANVAS_CHECK_BOUNDS
+
+#endif // DEV_ENABLED
+
+#endif // VISUAL_SERVER_CONSTANTS_H

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -682,6 +682,7 @@ public:
 
 	BIND0R(RID, canvas_item_create)
 	BIND2(canvas_item_set_parent, RID, RID)
+	BIND2(canvas_item_set_name, RID, String)
 
 	BIND2(canvas_item_set_visible, RID, bool)
 	BIND2(canvas_item_set_light_mask, RID, int)

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -583,6 +583,7 @@ public:
 
 	FUNCRID(canvas_item)
 	FUNC2(canvas_item_set_parent, RID, RID)
+	FUNC2(canvas_item_set_name, RID, String)
 
 	FUNC2(canvas_item_set_visible, RID, bool)
 	FUNC2(canvas_item_set_light_mask, RID, int)

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -1009,6 +1009,7 @@ public:
 
 	virtual RID canvas_item_create() = 0;
 	virtual void canvas_item_set_parent(RID p_item, RID p_parent) = 0;
+	virtual void canvas_item_set_name(RID p_item, String p_name) = 0;
 
 	virtual void canvas_item_set_visible(RID p_item, bool p_visible) = 0;
 	virtual void canvas_item_set_light_mask(RID p_item, int p_mask) = 0;


### PR DESCRIPTION
Adds optional hierarchical culling to the 2D rendering (within VisualServer).

Each canvas item maintains a bound in local space of the item itself and all child / grandchild items. This allows branches to be culled at once when they don't intersect a viewport.

Also caches global transforms and rects.

## Background
* @BimDav noticed in #63193 that culling in 2D is incredibly inefficient, in fact, it still does a lot of work for each item that is off screen.
* I noted in that PR that in addition to fixing the `VisibilityEnabler` to work with this, it might be possible to add some kind of automatic hierarchical culling, for instance using the scene graph, or a spatial partitioning structure such as BVH or similar.
* It turns out that unlike in 3D, for 2D, the hierarchical structure of the scene tree is stored in `VisualServer`, allowing the possibility for using this directly as spatial partitioning.

## How it works
* It stores one extra (non negligible) piece of data on each `Item` - the local bound. This is a `Rect2` indicating the bound in local space of the `Item` and all its non-hidden children and grandchildren.
* Additionally a dirty flag is stored to indicate whether the bound is dirty. This uses 1 bit and will combine with the other bitflags, so not using more memory.

### Housekeeping and Rendering
1) When changing the transform, or almost anything, about an `Item`, the bound of the item itself must be marked dirty (to be calculated next time). Additionally, the bounds of all parent items are marked dirty, as they may be modified.
2) During rendering, if a local bound is up to date (not dirty), it can be used for an intersection test with the viewport. If the bound is completely outside, all of the children can be culled. If the bound is _completely_ inside the viewport, none of the children need be tested, as they are all inside the viewport. If there is a partial intersection, the rendering proceeds as normal.
3) During rendering, if a local bound is dirty, it will not be used for culling, but will be calculated as the function traverses the tree, and marked as no longer dirty, for use on the next render.

## Costs and Benefits
There is thus a small housekeeping cost to the technique - probably around 2% (of the time taken by the preparation / culling code). In return the wins are quite significant. Overall the preparation phase is typically 4-10x faster.

In cases where a lot is off screen (and can thus be culled) the gains can be large. In @BimDav 's test project with 300,000 canvas items, the preparation code runs in the region of 16,000x faster, with a similar huge improvement to frame rate.

In the editor there are also speed improvements to the preparation / culling.

However, note that the preparation / culling is not always a major bottleneck, so even though there are huge improvements in the efficiency of preparation code, the overall boosts to frame rate are usually more modest.

Testing in `jetpaca`, I was typically getting increases from around 350 to 400fps, so about 15%.

## Notes
* As this is something that could potentially have regressions (particularly in y sorting), I have added it as an optional extra, and included the legacy path. This are now switchable in `project_settings/rendering/2d/options/cull_mode`, between `Item` mode (old style) and `Node` mode (which is now the default).
* I've also added caching of global rect and global transforms, these also give a modest increase in performance.
* There are some extra debugging functionality added. In particular, you can now switch a define to pass `canvas_item` names to the `VisualServer`, which enables you to identify nodes when printing the tree. This is normally switched off to save memory and performance. This can also be helpful for general 2D debugging in the `VisualServerCanvas`.

## Optional defines (in `visual_server_constants.h`)
* `VISUAL_SERVER_CANVAS_TIME_NODE_CULLING` - every 100 frames it runs both `Item` culling and `Node` culling, timing both, and displaying the timings using `print_line`. This enables direct comparison in different projects / scenes, and can be used in release.
* `VISUAL_SERVER_CANVAS_DEBUG_ITEM_NAMES` - pass canvas item names to VisualServer for debugging.
* `VISUAL_SERVER_CANVAS_CHECK_BOUNDS` - performs verification checks on all bounds to make sure they are correct and up to date, in order to detect bugs.
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
