### PR TITLE
Fix Polygon2D skinned bounds (for culling)

### DIFF
--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -1005,6 +1005,10 @@ public:
 		// in local space.
 		Rect2 local_bound;
 
+	private:
+		Rect2 calculate_polygon_bounds(const Item::CommandPolygon &p_polygon) const;
+
+	public:
 		const Rect2 &get_rect() const {
 			if (custom_rect) {
 				return rect;
@@ -1099,61 +1103,8 @@ public:
 					} break;
 					case Item::Command::TYPE_POLYGON: {
 						const Item::CommandPolygon *polygon = static_cast<const Item::CommandPolygon *>(c);
-						int l = polygon->points.size();
-						const Point2 *pp = &polygon->points[0];
-						r.position = pp[0];
-						for (int j = 1; j < l; j++) {
-							r.expand_to(pp[j]);
-						}
-
-						if (skeleton != RID()) {
-							// calculate bone AABBs
-							int bone_count = RasterizerStorage::base_singleton->skeleton_get_bone_count(skeleton);
-
-							Vector<Rect2> bone_aabbs;
-							bone_aabbs.resize(bone_count);
-							Rect2 *bptr = bone_aabbs.ptrw();
-
-							for (int j = 0; j < bone_count; j++) {
-								bptr[j].size = Vector2(-1, -1); //negative means unused
-							}
-							if (l && polygon->bones.size() == l * 4 && polygon->weights.size() == polygon->bones.size()) {
-								for (int j = 0; j < l; j++) {
-									Point2 p = pp[j];
-									for (int k = 0; k < 4; k++) {
-										int idx = polygon->bones[j * 4 + k];
-										float w = polygon->weights[j * 4 + k];
-										if (w == 0) {
-											continue;
-										}
-
-										if (bptr[idx].size.x < 0) {
-											//first
-											bptr[idx] = Rect2(p, Vector2(0.00001, 0.00001));
-										} else {
-											bptr[idx].expand_to(p);
-										}
-									}
-								}
-
-								Rect2 aabb;
-								bool first_bone = true;
-								for (int j = 0; j < bone_count; j++) {
-									Transform2D mtx = RasterizerStorage::base_singleton->skeleton_bone_get_transform_2d(skeleton, j);
-									Rect2 baabb = mtx.xform(bone_aabbs[j]);
-
-									if (first_bone) {
-										aabb = baabb;
-										first_bone = false;
-									} else {
-										aabb = aabb.merge(baabb);
-									}
-								}
-
-								r = r.merge(aabb);
-							}
-						}
-
+						DEV_ASSERT(polygon);
+						r = calculate_polygon_bounds(*polygon);
 					} break;
 					case Item::Command::TYPE_MESH: {
 						const Item::CommandMesh *mesh = static_cast<const Item::CommandMesh *>(c);


### PR DESCRIPTION
The bound Rect2 was previously incorrect because bone transforms need to be applied to verts in bone space, rather than local space. This was previously resulting in skinned Polygon2Ds being incorrectly culled.

Fixes ..63047 (2nd issue reported by hothex)

## Notes
* This error was introduced in ..40869 . The logic was copied from sections of code that were calculating the bone bounds, but this is not the same calculation needed for `Polygon2D` bounds.
* The canonical software transform for 2D skinning should now be referred to from `rasterizer_canvas_batcher`. This is the most tested path, and a number of bugs were solved there. https://github.com/godotengine/godot/blob/b0c399ec8c9f5f71c64656e8463907153f8459ff/drivers/gles_common/rasterizer_canvas_batcher.h#L1801-L1924
* This PR is adapted from that approach but has a simplification: the skeleton inverse base transform is not used in this PR. It may well be that we need to incorporate this too, as in the software skinning, but pulling this information is a little more involved so I am happy to leave this until we get an MRP that requires this. In any case this version is a vast improvement on before and should fix culling in the majority (and possibly all, until shown otherwise) cases.
* The code involved is moved from the h to cpp, as it is quite involved and should be capable of being inlined anyway (just as easily as from the header) as it is called from the same translation unit. Aside from comments, the only changes are to transform the point to bone space, and to untransform the final AABB.

## Extra
* The same bug is likely in 4.x, as reported in ..74656, this PR could be ported.
* The same bug may be present in 3D, we should double check bounds calculations are correct there also if it uses the same approach.
