### PR TITLE
Canvas item hierarchical culling - notify skeleton changes

### DIFF
--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -484,6 +484,7 @@ public:
 	void skeleton_bone_set_transform_2d(RID p_skeleton, int p_bone, const Transform2D &p_transform) {}
 	Transform2D skeleton_bone_get_transform_2d(RID p_skeleton, int p_bone) const { return Transform2D(); }
 	uint32_t skeleton_get_revision(RID p_skeleton) const { return 0; }
+	void skeleton_attach_canvas_item(RID p_skeleton, RID p_canvas_item, bool p_attach) {}
 
 	/* Light API */
 

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -903,6 +903,7 @@ public:
 		Set<RasterizerScene::InstanceBase *> instances;
 
 		Transform2D base_transform_2d;
+		LocalVector<RID> linked_canvas_items;
 
 		Skeleton() :
 				use_2d(false),
@@ -928,6 +929,7 @@ public:
 	virtual Transform2D skeleton_bone_get_transform_2d(RID p_skeleton, int p_bone) const;
 	virtual void skeleton_set_base_transform_2d(RID p_skeleton, const Transform2D &p_base_transform);
 	virtual uint32_t skeleton_get_revision(RID p_skeleton) const;
+	virtual void skeleton_attach_canvas_item(RID p_skeleton, RID p_canvas_item, bool p_attach);
 
 	void _update_skeleton_transform_buffer(const PoolVector<float> &p_data, size_t p_size);
 

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -926,7 +926,9 @@ public:
 		GLuint texture;
 		SelfList<Skeleton> update_list;
 		Set<RasterizerScene::InstanceBase *> instances; //instances using skeleton
+
 		Transform2D base_transform_2d;
+		LocalVector<RID> linked_canvas_items;
 
 		Skeleton() :
 				use_2d(false),
@@ -952,6 +954,7 @@ public:
 	virtual Transform2D skeleton_bone_get_transform_2d(RID p_skeleton, int p_bone) const;
 	virtual void skeleton_set_base_transform_2d(RID p_skeleton, const Transform2D &p_base_transform);
 	virtual uint32_t skeleton_get_revision(RID p_skeleton) const;
+	virtual void skeleton_attach_canvas_item(RID p_skeleton, RID p_canvas_item, bool p_attach);
 
 	/* Light API */
 

--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -96,6 +96,15 @@ void Polygon2D::_skeleton_bone_setup_changed() {
 
 void Polygon2D::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			// Must re-establish any existing links with skeletons on re-entering the tree.
+			update();
+		} break;
+		case NOTIFICATION_EXIT_TREE: {
+			// Always detach skeleton when exiting the tree, so skeletons don't inform
+			// Polygon2Ds outside the tree that they have moved (this would be useless work).
+			VS::get_singleton()->canvas_item_attach_skeleton(get_canvas_item(), RID());
+		} break;
 		case NOTIFICATION_DRAW: {
 			if (polygon.size() < 3) {
 				return;
@@ -664,4 +673,12 @@ Polygon2D::Polygon2D() {
 	rect_cache_dirty = true;
 	internal_vertices = 0;
 	current_skeleton_id = 0;
+}
+
+Polygon2D::~Polygon2D() {
+	// Most definitely don't want to leave references to this deleted canvas item
+	// in the skeleton.
+	if (get_canvas_item().is_valid()) {
+		VS::get_singleton()->canvas_item_attach_skeleton(get_canvas_item(), RID());
+	}
 }

--- a/scene/2d/polygon_2d.h
+++ b/scene/2d/polygon_2d.h
@@ -147,6 +147,7 @@ public:
 	NodePath get_skeleton() const;
 
 	Polygon2D();
+	virtual ~Polygon2D();
 };
 
 #endif // POLYGON_2D_H

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -449,6 +449,7 @@ public:
 	virtual Transform2D skeleton_bone_get_transform_2d(RID p_skeleton, int p_bone) const = 0;
 	virtual void skeleton_set_base_transform_2d(RID p_skeleton, const Transform2D &p_base_transform) = 0;
 	virtual uint32_t skeleton_get_revision(RID p_skeleton) const = 0;
+	virtual void skeleton_attach_canvas_item(RID p_skeleton, RID p_canvas_item, bool p_attach) = 0;
 
 	/* Light API */
 

--- a/servers/visual/visual_server_canvas.cpp
+++ b/servers/visual/visual_server_canvas.cpp
@@ -1440,7 +1440,33 @@ void VisualServerCanvas::canvas_item_attach_skeleton(RID p_item, RID p_skeleton)
 	Item *canvas_item = canvas_item_owner.getornull(p_item);
 	ERR_FAIL_COND(!canvas_item);
 
-	canvas_item->skeleton = p_skeleton;
+	if (_canvas_cull_mode == CANVAS_CULL_MODE_NODE) {
+		// No op?
+		if (canvas_item->skeleton == p_skeleton) {
+			return;
+		}
+
+		// Detach from any previous skeleton.
+		if (canvas_item->skeleton.is_valid()) {
+			VSG::storage->skeleton_attach_canvas_item(canvas_item->skeleton, p_item, false);
+		}
+
+		canvas_item->skeleton = p_skeleton;
+
+		// Attach to new skeleton.
+		if (p_skeleton.is_valid()) {
+			VSG::storage->skeleton_attach_canvas_item(p_skeleton, p_item, true);
+		}
+
+		_make_bound_dirty(canvas_item);
+	} else {
+		canvas_item->skeleton = p_skeleton;
+	}
+}
+
+void VisualServerCanvas::_canvas_item_skeleton_moved(RID p_item) {
+	Item *canvas_item = canvas_item_owner.getornull(p_item);
+	ERR_FAIL_COND(!canvas_item);
 	_make_bound_dirty(canvas_item);
 }
 

--- a/servers/visual/visual_server_canvas.h
+++ b/servers/visual/visual_server_canvas.h
@@ -251,6 +251,8 @@ public:
 	void canvas_item_set_z_as_relative_to_parent(RID p_item, bool p_enable);
 	void canvas_item_set_copy_to_backbuffer(RID p_item, bool p_enable, const Rect2 &p_rect);
 	void canvas_item_attach_skeleton(RID p_item, RID p_skeleton);
+	void _canvas_item_skeleton_moved(RID p_item);
+
 	void canvas_item_set_skeleton_relative_xform(RID p_item, Transform2D p_relative_xform);
 	Rect2 _debug_canvas_item_get_bounding_rect(RID p_item);
 


### PR DESCRIPTION
Skeleton changes affect the bound of Polygon2Ds, however as get_rect() normally uses a pull paradigm, changes to skeleton did not always take effect. In this PR skeleton keep a record of attached canvas items and notify them of changes to bounds.