### PR TITLE
2D Fixed Timestep Interpolation

### DIFF
--- a/core/math/transform_interpolator.cpp
+++ b/core/math/transform_interpolator.cpp
@@ -30,6 +30,49 @@
 
 #include "transform_interpolator.h"
 
+void TransformInterpolator::interpolate_transform2D(const Transform2D &p_prev, const Transform2D &p_curr, Transform2D &r_result, real_t p_fraction) {
+	//extract parameters
+	Vector2 p1 = p_prev.get_origin();
+	Vector2 p2 = p_curr.get_origin();
+
+	// Special case for physics interpolation, if flipping, don't interpolate basis.
+	// If the determinant polarity changes, the handedness of the coordinate system changes.
+	if (_sign(p_prev.basis_determinant()) != _sign(p_curr.basis_determinant())) {
+		r_result.elements[0] = p_curr.elements[0];
+		r_result.elements[1] = p_curr.elements[1];
+		r_result.set_origin(Vector2::linear_interpolate(p1, p2, p_fraction));
+		return;
+	}
+
+	real_t r1 = p_prev.get_rotation();
+	real_t r2 = p_curr.get_rotation();
+
+	Size2 s1 = p_prev.get_scale();
+	Size2 s2 = p_curr.get_scale();
+
+	//slerp rotation
+	Vector2 v1(Math::cos(r1), Math::sin(r1));
+	Vector2 v2(Math::cos(r2), Math::sin(r2));
+
+	real_t dot = v1.dot(v2);
+
+	dot = CLAMP(dot, -1, 1);
+
+	Vector2 v;
+
+	if (dot > 0.9995f) {
+		v = Vector2::linear_interpolate(v1, v2, p_fraction).normalized(); //linearly interpolate to avoid numerical precision issues
+	} else {
+		real_t angle = p_fraction * Math::acos(dot);
+		Vector2 v3 = (v2 - v1 * dot).normalized();
+		v = v1 * Math::cos(angle) + v3 * Math::sin(angle);
+	}
+
+	//construct matrix
+	r_result = Transform2D(Math::atan2(v.y, v.x), Vector2::linear_interpolate(p1, p2, p_fraction));
+	r_result.scale_basis(Vector2::linear_interpolate(s1, s2, p_fraction));
+}
+
 void TransformInterpolator::interpolate_transform(const Transform &p_prev, const Transform &p_curr, Transform &r_result, real_t p_fraction) {
 	r_result.origin = p_prev.origin + ((p_curr.origin - p_prev.origin) * p_fraction);
 	interpolate_basis(p_prev.basis, p_curr.basis, r_result.basis, p_fraction);

--- a/core/math/transform_interpolator.h
+++ b/core/math/transform_interpolator.h
@@ -66,6 +66,7 @@ private:
 	static Quat _basis_to_quat_unchecked(const Basis &p_basis);
 	static bool _basis_is_orthogonal(const Basis &p_basis, real_t p_epsilon = 0.01f);
 	static bool _basis_is_orthogonal_any_scale(const Basis &p_basis);
+	static bool _sign(real_t p_val) { return p_val >= 0; }
 
 	static void interpolate_basis_linear(const Basis &p_prev, const Basis &p_curr, Basis &r_result, real_t p_fraction);
 	static void interpolate_basis_scaled_slerp(Basis p_prev, Basis p_curr, Basis &r_result, real_t p_fraction);
@@ -75,6 +76,7 @@ public:
 	// These will be slower.
 	static void interpolate_transform(const Transform &p_prev, const Transform &p_curr, Transform &r_result, real_t p_fraction);
 	static void interpolate_basis(const Basis &p_prev, const Basis &p_curr, Basis &r_result, real_t p_fraction);
+	static void interpolate_transform2D(const Transform2D &p_prev, const Transform2D &p_curr, Transform2D &r_result, real_t p_fraction);
 
 	// Optimized function when you know ahead of time the method
 	static void interpolate_transform_via_method(const Transform &p_prev, const Transform &p_curr, Transform &r_result, real_t p_fraction, Method p_method);

--- a/core/os/main_loop.h
+++ b/core/os/main_loop.h
@@ -67,6 +67,7 @@ public:
 	virtual void input_text(const String &p_text);
 
 	virtual void init();
+	virtual void iteration_prepare() {}
 	virtual bool iteration(float p_time);
 	virtual void iteration_end() {}
 	virtual bool idle(float p_time);

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -825,6 +825,7 @@
 		<member name="mouse_filter" type="int" setter="set_mouse_filter" getter="get_mouse_filter" enum="Control.MouseFilter" default="0">
 			Controls whether the control will be able to receive mouse button input events through [method _gui_input] and how these events should be handled. Also controls whether the control can receive the [signal mouse_entered], and [signal mouse_exited] signals. See the constants to learn what each does.
 		</member>
+		<member name="physics_interpolation_mode" type="int" setter="set_physics_interpolation_mode" getter="get_physics_interpolation_mode" overrides="Node" enum="Node.PhysicsInterpolationMode" default="1" />
 		<member name="rect_clip_content" type="bool" setter="set_clip_contents" getter="is_clipping_contents" default="false">
 			Enables whether rendering of [CanvasItem] based children should be clipped to this control's rectangle. If [code]true[/code], parts of a child which would be visibly outside of this control's rectangle will not be rendered.
 		</member>

--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -325,6 +325,14 @@
 				Once finished with your RID, you will want to free the RID using the VisualServer's [method free_rid] static method.
 			</description>
 		</method>
+		<method name="canvas_item_reset_physics_interpolation">
+			<return type="void" />
+			<argument index="0" name="item" type="RID" />
+			<description>
+				Prevents physics interpolation for the current physics tick.
+				This is useful when moving a canvas item to a new location, to give an instantaneous change rather than interpolation from the previous location.
+			</description>
+		</method>
 		<method name="canvas_item_set_clip">
 			<return type="void" />
 			<argument index="0" name="item" type="RID" />
@@ -373,6 +381,14 @@
 			<argument index="1" name="index" type="int" />
 			<description>
 				Sets the index for the [CanvasItem].
+			</description>
+		</method>
+		<method name="canvas_item_set_interpolated">
+			<return type="void" />
+			<argument index="0" name="item" type="RID" />
+			<argument index="1" name="interpolated" type="bool" />
+			<description>
+				Turns on and off physics interpolation for the canvas item.
 			</description>
 		</method>
 		<method name="canvas_item_set_light_mask">
@@ -461,6 +477,16 @@
 			<argument index="1" name="z_index" type="int" />
 			<description>
 				Sets the [CanvasItem]'s Z index, i.e. its draw order (lower indexes are drawn first).
+			</description>
+		</method>
+		<method name="canvas_item_transform_physics_interpolation">
+			<return type="void" />
+			<argument index="0" name="item" type="RID" />
+			<argument index="1" name="xform" type="Transform2D" />
+			<description>
+				Transforms both the current and previous stored transform for a canvas item.
+				This allows transforming a canvas item without creating a "glitch" in the interpolation.
+				This is particularly useful for large worlds utilising a shifting origin.
 			</description>
 		</method>
 		<method name="canvas_light_attach_to_canvas">

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2298,6 +2298,12 @@ bool Main::iteration() {
 
 		PhysicsServer::get_singleton()->flush_queries();
 
+		// Prepare the fixed timestep interpolated nodes
+		// BEFORE they are updated by the physics 2D,
+		// otherwise the current and previous transforms
+		// may be the same, and no interpolation takes place.
+		OS::get_singleton()->get_main_loop()->iteration_prepare();
+
 		Physics2DServer::get_singleton()->sync();
 		Physics2DServer::get_singleton()->flush_queries();
 

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -94,6 +94,11 @@ protected:
 
 	Camera2DProcessMode process_mode;
 
+	struct InterpolationData {
+		Transform2D xform_curr;
+		Transform2D xform_prev;
+	} _interpolation_data;
+
 protected:
 	virtual Transform2D get_camera_transform();
 	void _notification(int p_what);

--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -562,6 +562,10 @@ void CanvasItem::_exit_canvas() {
 	}
 }
 
+void CanvasItem::_physics_interpolated_changed() {
+	VisualServer::get_singleton()->canvas_item_set_interpolated(canvas_item, is_physics_interpolated());
+}
+
 void CanvasItem::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
@@ -605,6 +609,12 @@ void CanvasItem::_notification(int p_what) {
 			}
 			global_invalid = true;
 		} break;
+		case NOTIFICATION_RESET_PHYSICS_INTERPOLATION: {
+			if (is_visible_in_tree() && is_physics_interpolated()) {
+				VisualServer::get_singleton()->canvas_item_reset_physics_interpolation(canvas_item);
+			}
+		} break;
+
 		case NOTIFICATION_DRAW:
 		case NOTIFICATION_TRANSFORM_CHANGED: {
 		} break;

--- a/scene/2d/canvas_item.h
+++ b/scene/2d/canvas_item.h
@@ -236,6 +236,7 @@ protected:
 	}
 
 	void item_rect_changed(bool p_size_changed = true);
+	virtual void _physics_interpolated_changed();
 
 	void _notification(int p_what);
 	static void _bind_methods();

--- a/scene/3d/visual_instance.cpp
+++ b/scene/3d/visual_instance.cpp
@@ -117,17 +117,6 @@ void VisualInstance::_notification(int p_what) {
 			if (_is_vi_visible() && is_physics_interpolated()) {
 				VisualServer::get_singleton()->instance_reset_physics_interpolation(instance);
 			}
-#if defined(DEBUG_ENABLED) && defined(TOOLS_ENABLED)
-			else if (GLOBAL_GET("debug/settings/physics_interpolation/enable_warnings")) {
-				String node_name = is_inside_tree() ? String(get_path()) : String(get_name());
-				if (!_is_vi_visible()) {
-					WARN_PRINT("[Physics interpolation] NOTIFICATION_RESET_PHYSICS_INTERPOLATION only works with unhidden nodes: \"" + node_name + "\".");
-				}
-				if (!is_physics_interpolated()) {
-					WARN_PRINT("[Physics interpolation] NOTIFICATION_RESET_PHYSICS_INTERPOLATION only works with interpolated nodes: \"" + node_name + "\".");
-				}
-			}
-#endif
 		} break;
 		case NOTIFICATION_EXIT_WORLD: {
 			VisualServer::get_singleton()->instance_set_scenario(instance, RID());

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -3003,6 +3003,8 @@ Control::Control() {
 	}
 	data.focus_mode = FOCUS_NONE;
 	data.modal_prev_focus_owner = 0;
+
+	set_physics_interpolation_mode(Node::PHYSICS_INTERPOLATION_MODE_OFF);
 }
 
 Control::~Control() {

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -554,6 +554,12 @@ void SceneTree::client_physics_interpolation_remove_spatial(SelfList<Spatial> *p
 	_client_physics_interpolation._spatials_list.remove(p_elem);
 }
 
+void SceneTree::iteration_prepare() {
+	if (_physics_interpolation_enabled) {
+		VisualServer::get_singleton()->tick();
+	}
+}
+
 void SceneTree::iteration_end() {
 	// When physics interpolation is active, we want all pending transforms
 	// to be flushed to the VisualServer before finishing a physics tick.
@@ -566,10 +572,6 @@ bool SceneTree::iteration(float p_time) {
 	root_lock++;
 
 	current_frame++;
-
-	if (_physics_interpolation_enabled) {
-		VisualServer::get_singleton()->tick();
-	}
 
 	// Any objects performing client physics interpolation
 	// should be given an opportunity to keep their previous transforms

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -321,6 +321,7 @@ public:
 	virtual void input_event(const Ref<InputEvent> &p_event);
 	virtual void init();
 
+	virtual void iteration_prepare();
 	virtual bool iteration(float p_time);
 	virtual void iteration_end();
 	virtual bool idle(float p_time);

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -977,13 +977,19 @@ public:
 			Rect2 rect;
 		};
 
-		Transform2D xform;
+		// For interpolation we store the current local xform,
+		// and the previous xform from the previous tick.
+		Transform2D xform_curr;
+		Transform2D xform_prev;
+
 		bool clip : 1;
 		bool visible : 1;
 		bool behind : 1;
 		bool update_when_visible : 1;
 		bool distance_field : 1;
 		bool light_masked : 1;
+		bool on_interpolate_transform_list : 1;
+		bool interpolated : 1;
 		mutable bool custom_rect : 1;
 		mutable bool rect_dirty : 1;
 		mutable bool bound_dirty : 1;
@@ -1191,6 +1197,7 @@ public:
 			final_clip_owner = nullptr;
 			material_owner = nullptr;
 			light_masked = false;
+			on_interpolate_transform_list = false;
 
 			if (skinning_data) {
 				memdelete(skinning_data);
@@ -1215,6 +1222,8 @@ public:
 			distance_field = false;
 			light_masked = false;
 			update_when_visible = false;
+			on_interpolate_transform_list = false;
+			interpolated = true;
 		}
 		virtual ~Item() {
 			clear();

--- a/servers/visual/visual_server_canvas.h
+++ b/servers/visual/visual_server_canvas.h
@@ -250,6 +250,9 @@ public:
 	void canvas_item_set_z_index(RID p_item, int p_z);
 	void canvas_item_set_z_as_relative_to_parent(RID p_item, bool p_enable);
 	void canvas_item_set_copy_to_backbuffer(RID p_item, bool p_enable, const Rect2 &p_rect);
+	void canvas_item_set_interpolated(RID p_item, bool p_interpolated);
+	void canvas_item_reset_physics_interpolation(RID p_item);
+	void canvas_item_transform_physics_interpolation(RID p_item, Transform2D p_transform);
 	void canvas_item_attach_skeleton(RID p_item, RID p_skeleton);
 	void _canvas_item_skeleton_moved(RID p_item);
 
@@ -301,6 +304,21 @@ public:
 	void canvas_occluder_polygon_set_cull_mode(RID p_occluder_polygon, VS::CanvasOccluderPolygonCullMode p_mode);
 
 	bool free(RID p_rid);
+
+	// Interpolation
+	void tick();
+	void update_interpolation_tick(bool p_process = true);
+	void set_physics_interpolation_enabled(bool p_enabled) { _interpolation_data.interpolation_enabled = p_enabled; }
+
+	struct InterpolationData {
+		void notify_free_canvas_item(RID p_rid, VisualServerCanvas::Item &r_canvas_item);
+		LocalVector<RID> canvas_item_transform_update_lists[2];
+		LocalVector<RID> *canvas_item_transform_update_list_curr = &canvas_item_transform_update_lists[0];
+		LocalVector<RID> *canvas_item_transform_update_list_prev = &canvas_item_transform_update_lists[1];
+
+		bool interpolation_enabled = false;
+	} _interpolation_data;
+
 	VisualServerCanvas();
 	~VisualServerCanvas();
 };

--- a/servers/visual/visual_server_raster.cpp
+++ b/servers/visual/visual_server_raster.cpp
@@ -136,6 +136,21 @@ void VisualServerRaster::draw(bool p_swap_buffers, double frame_step) {
 void VisualServerRaster::sync() {
 }
 
+void VisualServerRaster::set_physics_interpolation_enabled(bool p_enabled) {
+	VSG::scene->set_physics_interpolation_enabled(p_enabled);
+	VSG::canvas->set_physics_interpolation_enabled(p_enabled);
+}
+
+void VisualServerRaster::tick() {
+	VSG::scene->tick();
+	VSG::canvas->tick();
+}
+
+void VisualServerRaster::pre_draw(bool p_will_draw) {
+	VSG::scene->pre_draw(p_will_draw);
+	// VSG::canvas->pre_draw(p_will_draw);
+}
+
 bool VisualServerRaster::has_changed(ChangedPriority p_priority) const {
 	switch (p_priority) {
 		default: {

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -454,9 +454,6 @@ public:
 
 	/* EVENT QUEUING */
 
-	BIND0N(tick)
-	BIND1N(pre_draw, bool)
-
 	/* CAMERA API */
 
 	BIND0R(RID, camera_create)
@@ -558,10 +555,6 @@ public:
 
 #undef BINDBASE
 #define BINDBASE VSG::scene
-
-	/* INTERPOLATION */
-
-	BIND1(set_physics_interpolation_enabled, bool)
 
 	/* SCENARIO API */
 
@@ -719,6 +712,10 @@ public:
 	BIND2(canvas_item_set_z_index, RID, int)
 	BIND2(canvas_item_set_z_as_relative_to_parent, RID, bool)
 	BIND3(canvas_item_set_copy_to_backbuffer, RID, bool, const Rect2 &)
+	BIND2(canvas_item_set_interpolated, RID, bool)
+	BIND1(canvas_item_reset_physics_interpolation, RID)
+	BIND2(canvas_item_transform_physics_interpolation, RID, Transform2D)
+
 	BIND2(canvas_item_attach_skeleton, RID, RID)
 	BIND2(canvas_item_set_skeleton_relative_xform, RID, Transform2D)
 	BIND1R(Rect2, _debug_canvas_item_get_rect, RID)
@@ -780,11 +777,15 @@ public:
 
 	virtual void request_frame_drawn_callback(Object *p_where, const StringName &p_method, const Variant &p_userdata);
 
+	virtual void tick();
+	virtual void pre_draw(bool p_will_draw);
 	virtual void draw(bool p_swap_buffers, double frame_step);
 	virtual void sync();
 	virtual bool has_changed(ChangedPriority p_priority = CHANGED_PRIORITY_ANY) const;
 	virtual void init();
 	virtual void finish();
+
+	virtual void set_physics_interpolation_enabled(bool p_enabled);
 
 	/* STATUS INFORMATION */
 

--- a/servers/visual/visual_server_wrap_mt.cpp
+++ b/servers/visual/visual_server_wrap_mt.cpp
@@ -70,6 +70,30 @@ void VisualServerWrapMT::thread_loop() {
 
 /* EVENT QUEUING */
 
+void VisualServerWrapMT::set_physics_interpolation_enabled(bool p_enabled) {
+	if (Thread::get_caller_id() != server_thread) {
+		command_queue.push(visual_server, &VisualServer::set_physics_interpolation_enabled, p_enabled);
+	} else {
+		visual_server->set_physics_interpolation_enabled(p_enabled);
+	}
+}
+
+void VisualServerWrapMT::tick() {
+	if (Thread::get_caller_id() != server_thread) {
+		command_queue.push(visual_server, &VisualServer::tick);
+	} else {
+		visual_server->tick();
+	}
+}
+
+void VisualServerWrapMT::pre_draw(bool p_will_draw) {
+	if (Thread::get_caller_id() != server_thread) {
+		command_queue.push(visual_server, &VisualServer::pre_draw, p_will_draw);
+	} else {
+		visual_server->pre_draw(p_will_draw);
+	}
+}
+
 void VisualServerWrapMT::sync() {
 	if (create_thread) {
 		command_queue.push_and_sync(this, &VisualServerWrapMT::thread_flush);

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -464,10 +464,6 @@ public:
 	FUNC7(environment_set_fog_depth, RID, bool, float, float, float, bool, float)
 	FUNC5(environment_set_fog_height, RID, bool, float, float, float)
 
-	/* INTERPOLATION API */
-
-	FUNC1(set_physics_interpolation_enabled, bool)
-
 	/* SCENARIO API */
 
 	FUNCRID(scenario)
@@ -620,6 +616,10 @@ public:
 	FUNC2(canvas_item_set_z_index, RID, int)
 	FUNC2(canvas_item_set_z_as_relative_to_parent, RID, bool)
 	FUNC3(canvas_item_set_copy_to_backbuffer, RID, bool, const Rect2 &)
+	FUNC2(canvas_item_set_interpolated, RID, bool)
+	FUNC1(canvas_item_reset_physics_interpolation, RID)
+	FUNC2(canvas_item_transform_physics_interpolation, RID, Transform2D)
+
 	FUNC2(canvas_item_attach_skeleton, RID, RID)
 	FUNC2(canvas_item_set_skeleton_relative_xform, RID, Transform2D)
 	FUNC1R(Rect2, _debug_canvas_item_get_rect, RID)
@@ -683,11 +683,12 @@ public:
 
 	virtual void init();
 	virtual void finish();
+	virtual void tick();
+	virtual void pre_draw(bool p_will_draw);
 	virtual void draw(bool p_swap_buffers, double frame_step);
 	virtual void sync();
-	FUNC0(tick)
-	FUNC1(pre_draw, bool)
 	FUNC1RC(bool, has_changed, ChangedPriority)
+	virtual void set_physics_interpolation_enabled(bool p_enabled);
 
 	/* RENDER INFO */
 

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2215,6 +2215,9 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("canvas_item_set_z_index", "item", "z_index"), &VisualServer::canvas_item_set_z_index);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_z_as_relative_to_parent", "item", "enabled"), &VisualServer::canvas_item_set_z_as_relative_to_parent);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_copy_to_backbuffer", "item", "enabled", "rect"), &VisualServer::canvas_item_set_copy_to_backbuffer);
+	ClassDB::bind_method(D_METHOD("canvas_item_set_interpolated", "item", "interpolated"), &VisualServer::canvas_item_set_interpolated);
+	ClassDB::bind_method(D_METHOD("canvas_item_reset_physics_interpolation", "item"), &VisualServer::canvas_item_reset_physics_interpolation);
+	ClassDB::bind_method(D_METHOD("canvas_item_transform_physics_interpolation", "item", "xform"), &VisualServer::canvas_item_transform_physics_interpolation);
 	ClassDB::bind_method(D_METHOD("canvas_item_clear", "item"), &VisualServer::canvas_item_clear);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_draw_index", "item", "index"), &VisualServer::canvas_item_set_draw_index);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_material", "item", "material"), &VisualServer::canvas_item_set_material);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -1055,6 +1055,9 @@ public:
 	virtual void canvas_item_set_z_index(RID p_item, int p_z) = 0;
 	virtual void canvas_item_set_z_as_relative_to_parent(RID p_item, bool p_enable) = 0;
 	virtual void canvas_item_set_copy_to_backbuffer(RID p_item, bool p_enable, const Rect2 &p_rect) = 0;
+	virtual void canvas_item_set_interpolated(RID p_item, bool p_interpolated) = 0;
+	virtual void canvas_item_reset_physics_interpolation(RID p_item) = 0;
+	virtual void canvas_item_transform_physics_interpolation(RID p_item, Transform2D p_transform) = 0;
 
 	virtual void canvas_item_attach_skeleton(RID p_item, RID p_skeleton) = 0;
 	virtual void canvas_item_set_skeleton_relative_xform(RID p_item, Transform2D p_relative_xform) = 0;


### PR DESCRIPTION
Adds support to canvas items and Camera2D.

## Notes
* No support yet for scene side `get_global_transform_interpolated()`
* Adds `canvas_item_transform_physics_interpolation()` to allow origin shifting techniques
* On / off per node is handled by the same `InterpolationMode` as 3D
* In order to sensibly interpolate detect sprite flips there is some extra interpolation code in `TransformInterpolator`
* Switch off by default in GUI `Controls`
* `reset_physics_interpolation()` support as in 3D