### PR TITLE
Hierarchical 2D culling - use interpolated bound

### DIFF
--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -806,6 +806,14 @@
 				Modulates all colors in the given canvas.
 			</description>
 		</method>
+		<method name="debug_canvas_item_get_local_bound">
+			<return type="Rect2" />
+			<argument index="0" name="item" type="RID" />
+			<description>
+				Returns the bounding rectangle for a canvas item and its descendants in local space, as calculated by the renderer. This bound is used internally for culling.
+				[b]Warning:[/b] This function is intended for debugging in the editor, and will pass through and return a zero [Rect2] in exported projects.
+			</description>
+		</method>
 		<method name="debug_canvas_item_get_rect">
 			<return type="Rect2" />
 			<argument index="0" name="item" type="RID" />

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -1036,6 +1036,13 @@ public:
 		// in local space.
 		Rect2 local_bound;
 
+		// When using interpolation, the local bound for culling
+		// should be a combined bound of the previous and current.
+		// To keep this up to date, we need to keep track of the previous
+		// bound separately rather than just the combined bound.
+		Rect2 local_bound_prev;
+		uint32_t local_bound_last_update_tick;
+
 	private:
 		Rect2 calculate_polygon_bounds(const Item::CommandPolygon &p_polygon) const;
 		void precalculate_polygon_bone_bounds(const Item::CommandPolygon &p_polygon) const;
@@ -1229,6 +1236,7 @@ public:
 			update_when_visible = false;
 			on_interpolate_transform_list = false;
 			interpolated = true;
+			local_bound_last_update_tick = 0;
 		}
 		virtual ~Item() {
 			clear();

--- a/servers/visual/visual_server_canvas.h
+++ b/servers/visual/visual_server_canvas.h
@@ -259,6 +259,7 @@ public:
 	void _canvas_item_skeleton_moved(RID p_item);
 	void canvas_item_set_skeleton_relative_xform(RID p_item, Transform2D p_relative_xform);
 	Rect2 _debug_canvas_item_get_rect(RID p_item);
+	Rect2 _debug_canvas_item_get_local_bound(RID p_item);
 
 	void canvas_item_set_interpolated(RID p_item, bool p_interpolated);
 	void canvas_item_reset_physics_interpolation(RID p_item);

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -720,6 +720,7 @@ public:
 	BIND2(canvas_item_attach_skeleton, RID, RID)
 	BIND2(canvas_item_set_skeleton_relative_xform, RID, Transform2D)
 	BIND1R(Rect2, _debug_canvas_item_get_rect, RID)
+	BIND1R(Rect2, _debug_canvas_item_get_local_bound, RID)
 
 	BIND2(canvas_item_set_interpolated, RID, bool)
 	BIND1(canvas_item_reset_physics_interpolation, RID)

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -624,6 +624,7 @@ public:
 	FUNC2(canvas_item_attach_skeleton, RID, RID)
 	FUNC2(canvas_item_set_skeleton_relative_xform, RID, Transform2D)
 	FUNC1R(Rect2, _debug_canvas_item_get_rect, RID)
+	FUNC1R(Rect2, _debug_canvas_item_get_local_bound, RID)
 
 	FUNC2(canvas_item_set_interpolated, RID, bool)
 	FUNC1(canvas_item_reset_physics_interpolation, RID)

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2223,6 +2223,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("canvas_item_set_material", "item", "material"), &VisualServer::canvas_item_set_material);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_use_parent_material", "item", "enabled"), &VisualServer::canvas_item_set_use_parent_material);
 	ClassDB::bind_method(D_METHOD("debug_canvas_item_get_rect", "item"), &VisualServer::debug_canvas_item_get_rect);
+	ClassDB::bind_method(D_METHOD("debug_canvas_item_get_local_bound", "item"), &VisualServer::debug_canvas_item_get_local_bound);
 	ClassDB::bind_method(D_METHOD("canvas_light_create"), &VisualServer::canvas_light_create);
 	ClassDB::bind_method(D_METHOD("canvas_light_attach_to_canvas", "light", "canvas"), &VisualServer::canvas_light_attach_to_canvas);
 	ClassDB::bind_method(D_METHOD("canvas_light_set_enabled", "light", "enabled"), &VisualServer::canvas_light_set_enabled);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -1062,15 +1062,16 @@ public:
 
 	virtual void canvas_item_attach_skeleton(RID p_item, RID p_skeleton) = 0;
 	virtual void canvas_item_set_skeleton_relative_xform(RID p_item, Transform2D p_relative_xform) = 0;
-	Rect2 debug_canvas_item_get_rect(RID p_item) {
 #ifdef TOOLS_ENABLED
-		return _debug_canvas_item_get_rect(p_item);
+	Rect2 debug_canvas_item_get_rect(RID p_item) { return _debug_canvas_item_get_rect(p_item); }
+	Rect2 debug_canvas_item_get_local_bound(RID p_item) { return _debug_canvas_item_get_local_bound(p_item); }
 #else
-		return Rect2();
+	Rect2 debug_canvas_item_get_rect(RID p_item) { return Rect2; }
+	Rect2 debug_canvas_item_get_local_bound(RID p_item) { return Rect2; }
 #endif
-	}
 
 	virtual Rect2 _debug_canvas_item_get_rect(RID p_item) = 0;
+	virtual Rect2 _debug_canvas_item_get_local_bound(RID p_item) = 0;
 	virtual void canvas_item_set_interpolated(RID p_item, bool p_interpolated) = 0;
 	virtual void canvas_item_reset_physics_interpolation(RID p_item) = 0;
 	virtual void canvas_item_transform_physics_interpolation(RID p_item, Transform2D p_transform) = 0;


### PR DESCRIPTION
When interpolation is active, if we cull using only the current bound, false negatives can occur. We must instead cull using the combined bound of the previous and current tick.

This combined bound should also be reduced when an item stops moving (to minimize the cull bound).