### PR TITLE
2D Fixed Timestep Interpolation - Fixup

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -74,6 +74,12 @@ void Camera2D::_update_process_mode() {
 	if (is_physics_interpolated_and_enabled()) {
 		set_process_internal(is_current());
 		set_physics_process_internal(is_current());
+
+#ifdef TOOLS_ENABLED
+		if (process_mode == CAMERA2D_PROCESS_IDLE) {
+			WARN_PRINT_ONCE("Camera2D overridden to physics process mode due to use of physics interpolation.");
+		}
+#endif
 	} else {
 		// smoothing can be enabled in the editor but will never be active
 		if (process_mode == CAMERA2D_PROCESS_IDLE) {
@@ -188,7 +194,11 @@ Transform2D Camera2D::get_camera_transform() {
 		}
 
 		if (smoothing_active) {
-			float c = smoothing * (process_mode == CAMERA2D_PROCESS_PHYSICS ? get_physics_process_delta_time() : get_process_delta_time());
+			// Note that if we are using physics interpolation,
+			// processing will always be physics based (it ignores the process mode set in the UI).
+			bool physics_process = (process_mode == CAMERA2D_PROCESS_PHYSICS) || is_physics_interpolated_and_enabled();
+			float delta = physics_process ? get_physics_process_delta_time() : get_process_delta_time();
+			float c = smoothing * delta;
 			smoothed_camera_pos = ((camera_pos - smoothed_camera_pos) * c) + smoothed_camera_pos;
 			ret_camera_pos = smoothed_camera_pos;
 		} else {

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -1215,6 +1215,7 @@ public:
 				memdelete(skinning_data);
 				skinning_data = nullptr;
 			}
+			on_interpolate_transform_list = false;
 		}
 		Item() {
 			light_mask = 1;

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -1072,6 +1072,7 @@ public:
 
 	virtual Rect2 _debug_canvas_item_get_rect(RID p_item) = 0;
 	virtual Rect2 _debug_canvas_item_get_local_bound(RID p_item) = 0;
+
 	virtual void canvas_item_set_interpolated(RID p_item, bool p_interpolated) = 0;
 	virtual void canvas_item_reset_physics_interpolation(RID p_item) = 0;
 	virtual void canvas_item_transform_physics_interpolation(RID p_item, Transform2D p_transform) = 0;


### PR DESCRIPTION
Adds support to canvas items and Camera2D.

Just a fixup to keep godot-plus in sync with the main Godot PR.